### PR TITLE
Document build process and refine util test

### DIFF
--- a/README
+++ b/README
@@ -40,6 +40,25 @@ The web page for this distribution is
 
     http://www.nordier.com/software/obcpl.html
 
+Build
+
+See INSTALL for detailed build instructions. Build the compiler with
+
+    ./makeall
+
+and then install it, optionally overriding `PREFIX` to choose an
+installation directory:
+
+    ./makeall install
+
+Ensure the resulting `bcplc` driver is on your `PATH` (or supply a
+`BC` variable pointing to it). Once the compiler is available, enter
+the "util" directory and run
+
+    make test
+
+to compile and execute the "cmpltest" suite.
+
 
 Robert Nordier
 www.nordier.com

--- a/util/Makefile
+++ b/util/Makefile
@@ -1,7 +1,7 @@
 # Makefile for bcplc/util
 
-BC=bcplc
-BFLAGS=-O
+BC ?= bcplc
+BFLAGS ?= -O
 
 all: cmpltest xref gpm
 
@@ -14,9 +14,13 @@ xref: xref.bcpl
 gpm: gpm.bcpl
 	$(BC) $(BFLAGS) gpm.bcpl
 
+test: cmpltest
+	./cmpltest
+
 install:
 
 clean:
 	rm -f cmpltest cmpltest.o
 	rm -f xref xref.o
 	rm -f gpm gpm.o
+.PHONY: all test install clean


### PR DESCRIPTION
## Summary
- document how to build and install the compiler before running tests
- allow overriding `BC` and `BFLAGS` in `util/Makefile`
- mark common targets as `.PHONY`

## Testing
- `make -C util test` *(fails: `/usr/local/lib/bcplc/st: Exec format error`)*