### PR TITLE
Add CodeQL and Reviewdog workflows

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,9 @@
+name: Custom CodeQL Configuration
+
+queries:
+  - uses: security-extended
+  - uses: codeql-suites/analysis-optimizations
+
+paths-ignore:
+  - '**/tests/**'
+  - '**/examples/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: sh makeall all

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,74 @@
+name: codeql-multilang
+
+on:
+  push:
+    branches: [main, release/**]
+  pull_request:
+    branches: [main, release/**]
+  schedule:
+    - cron:  '25 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+env:
+  BUNDLE_ARTIFACT: codeql-custom-bundle.tgz
+
+jobs:
+  build-bundle:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build CodeQL bundle
+      uses: advanced-security/codeql-bundle-action@v2
+      with:
+        packs: |
+          codeql/javascript-queries@latest
+          codeql/cpp-queries@latest
+          my-org/my-extra-python-pack@~1.4
+        output: ${{ env.BUNDLE_ARTIFACT }}
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.BUNDLE_ARTIFACT }}
+        path: ${{ env.BUNDLE_ARTIFACT }}
+        retention-days: 5
+
+  codeql-scan:
+    needs: build-bundle
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lang: "c-cpp"
+          - lang: "python"
+          - lang: "go"
+          - lang: "javascript-typescript"
+          - lang: "ruby"
+          - lang: "rust"
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: ${{ env.BUNDLE_ARTIFACT }}
+
+    - name: Initialise CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.lang }}
+        config-file: .github/codeql/codeql-config.yml
+        tools: ${{ env.BUNDLE_ARTIFACT }}
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{ matrix.lang }}"
+        output: sarif

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,47 @@
+name: lint-and-annotate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        linter:
+          - { id: "shellcheck", cmd: "shellcheck -f gcc $(git ls-files '*.sh')" }
+          - { id: "black",       cmd: "black --check --diff ." }
+          - { id: "golangci",    cmd: "golangci-lint run --out-format=checkstyle" }
+          - { id: "ruff",        cmd: "ruff --output-format=github ." }
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+    - uses: actions/setup-python@v5
+
+    - name: Install linter runtime deps
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y shellcheck
+
+    - name: Run ${{ matrix.linter.id }} & feed Reviewdog
+      uses: reviewdog/reviewdog@master
+      with:
+        name: ${{ matrix.linter.id }}
+        reporter: github-pr-check
+        filter_mode: diff_context
+        fail_level: error
+        run: ${{ matrix.linter.cmd }}
+        level: warning
+
+    - name: Emit summary
+      if: always()
+      run: reviewdog -reporter=local -format=rdjson -f .rdjson > $RUNNER_TEMP/rd.json


### PR DESCRIPTION
## Summary
- add a multi-language CodeQL workflow using codeql-bundle
- add a universal lint workflow powered by Reviewdog
- introduce a simple CodeQL config
- create a basic CI workflow for building the project
- track Reviewdog from the master branch

## Testing
- `sh makeall all`
