### PR TITLE
Begin 64-bit port

### DIFF
--- a/README
+++ b/README
@@ -45,6 +45,9 @@ After installation, verify the compiler by running::
 
     bcplc util/cmpltest.bcpl
 
+The runtime components now build as native 64-bit executables.
+Support for ``qemu-i386`` is therefore no longer required.
+
 This should print::
 
     119 TESTS COMPLETED, 0 FAILURE(S)
@@ -78,7 +81,8 @@ the "util" directory and run
 
     make test
 
-to compile and execute the "cmpltest" suite.
+to compile and execute the "cmpltest" suite using the new 64-bit
+runtime system.
 
 
 Robert Nordier

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@
 
 PREFIX?=/usr/local
 
-AFLAGS=--32
+AFLAGS=--64
 
 all: cg op st
 
@@ -25,7 +25,7 @@ pt.o: pt.c
 	$(CC) $(CFLAGS) -c pt.c
 
 st: su.o st.o blib.o global.o rt.o sys.o
-	ld -m elf_i386 -o st su.o st.o blib.o global.o rt.o sys.o
+	ld -m elf_x86_64 -o st su.o st.o blib.o global.o rt.o sys.o
 
 su.o: su.s
 	$(AS) $(AFLAGS) -o su.o su.s

--- a/src/bcplc
+++ b/src/bcplc
@@ -12,6 +12,8 @@ error()
 d=/usr/local/lib/bcplc
 ohead="$d/su.o"
 otail="$d/blib.o $d/global.o $d/rt.o $d/sys.o"
+
+stcmd="$d/st"
 Oflag=0
 cflag=4
 args=`getopt COSco: $*`
@@ -68,13 +70,13 @@ do
             ofile=/tmp/$$_tmp.$x
         fi
         case $i in
-        1) $d/st < $ifile > $ofile ;;
+        1) $stcmd < $ifile > $ofile ;;
         2) if test $Oflag -eq 0; then
                $d/cg < $ifile > $ofile
            else
                $d/cg < $ifile | $d/op > $ofile
            fi ;;
-        3) as --32 -o $ofile $ifile ;;
+        3) as --64 -o $ofile $ifile ;;
         esac
         ifile=$ofile
         i=$(($i+1))
@@ -83,5 +85,5 @@ do
     rm -f /tmp/$$_tmp.*
 done
 if test $cflag -eq 4; then
-    ld -m elf_i386 -o $oname $ohead $olist $otail
+    ld -m elf_x86_64 -o $oname $ohead $olist $otail
 fi


### PR DESCRIPTION
## Summary
- start refactoring build for a 64-bit toolchain
- update README to mention 64-bit runtime
- adjust bcplc driver and Makefile to assemble and link for x86-64

## Testing
- `sh ./makeall` *(fails: operand size mismatch in `su.s`)*
- `sh ./makeall install` *(fails: assembler error in `su.s`)*
- `sh src/bcplc util/cmpltest.bcpl` *(fails: runtime not built)*
- `make -C util test` *(fails: bcplc not found)*