### PR TITLE
build: add initial CMake files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ src/st
 src/cg
 src/op
 util/*
+build/
 
 # Symlink to system libraries
 src/sys.s

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.10)
+project(bcplc C)
+
+option(BOOTSTRAP "Regenerate st.s using built cg/op" OFF)
+
+add_subdirectory(src)
+add_subdirectory(util)
+add_subdirectory(doc)

--- a/README
+++ b/README
@@ -75,6 +75,17 @@ installation directory:
 
     ./makeall install
 
+The project also provides CMake files.  A typical out-of-tree build
+looks like::
+
+    cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/usr/local
+    cmake --build build
+    cmake --install build
+
+Pass ``-DBOOTSTRAP=ON`` to regenerate ``st.s`` using the freshly built
+code generator and optimizer.  The ``util`` and ``doc`` targets may be
+built from the same build directory.
+
 Ensure the resulting `bcplc` driver is on your `PATH` (or supply a
 `BC` variable pointing to it). Once the compiler is available, enter
 the "util" directory and run

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.10)
+
+add_custom_target(doc ALL)
+
+install(FILES manual.txt standard.txt DESTINATION share/doc/BCPL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,69 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Build backend programs cg and op
+add_executable(cg cg.c oc.c)
+add_executable(op op.c pt.c)
+
+set(AS_FLAGS --64)
+set(BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR})
+set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+function(add_asm_object out src)
+    add_custom_command(
+        OUTPUT ${out}
+        COMMAND as ${AS_FLAGS} -o ${out} ${src}
+        DEPENDS ${src}
+        WORKING_DIRECTORY ${BUILD_DIR}
+        VERBATIM)
+endfunction()
+
+add_asm_object(${BUILD_DIR}/su.o ${SRC_DIR}/su.s)
+add_asm_object(${BUILD_DIR}/blib.o ${SRC_DIR}/blib.s)
+add_asm_object(${BUILD_DIR}/global.o ${SRC_DIR}/global.s)
+add_asm_object(${BUILD_DIR}/rt.o ${SRC_DIR}/rt.s)
+add_asm_object(${BUILD_DIR}/sys.o ${SRC_DIR}/sys.s)
+
+set(ST_SRC ${SRC_DIR}/st.s)
+if(BOOTSTRAP)
+    add_custom_command(
+        OUTPUT ${BUILD_DIR}/st.s
+        COMMAND bash -c "$<TARGET_FILE:cg> < ${SRC_DIR}/st.O | $<TARGET_FILE:op> > st.s"
+        WORKING_DIRECTORY ${BUILD_DIR}
+        DEPENDS cg op ${SRC_DIR}/st.O
+        VERBATIM)
+    set(ST_SRC ${BUILD_DIR}/st.s)
+endif()
+
+add_custom_command(
+    OUTPUT ${BUILD_DIR}/st.o
+    COMMAND as ${AS_FLAGS} -o st.o ${ST_SRC}
+    DEPENDS ${ST_SRC}
+    WORKING_DIRECTORY ${BUILD_DIR}
+    VERBATIM)
+
+set(RUNTIME_OBJS
+    ${BUILD_DIR}/su.o
+    ${BUILD_DIR}/st.o
+    ${BUILD_DIR}/blib.o
+    ${BUILD_DIR}/global.o
+    ${BUILD_DIR}/rt.o
+    ${BUILD_DIR}/sys.o)
+
+add_custom_command(
+    OUTPUT ${BUILD_DIR}/st
+    COMMAND ld -m elf_x86_64 -o st ${RUNTIME_OBJS}
+    DEPENDS ${RUNTIME_OBJS}
+    WORKING_DIRECTORY ${BUILD_DIR}
+    VERBATIM)
+
+add_custom_target(runtime ALL DEPENDS ${BUILD_DIR}/st)
+
+# Installation
+install(TARGETS cg op RUNTIME DESTINATION lib/bcplc)
+install(PROGRAMS ${BUILD_DIR}/st DESTINATION lib/bcplc)
+install(PROGRAMS bcplc DESTINATION bin)
+install(FILES bcplc.1 DESTINATION share/man/man1)
+install(FILES LIBHDR DESTINATION lib/bcplc)
+install(FILES ${BUILD_DIR}/su.o ${BUILD_DIR}/blib.o ${BUILD_DIR}/global.o
+              ${BUILD_DIR}/rt.o ${BUILD_DIR}/sys.o
+        DESTINATION lib/bcplc)


### PR DESCRIPTION
## Summary
- add root CMake file and subdirectory rules
- provide CMake build logic for backend in `src/`
- add CMake support for utilities and docs
- document CMake usage and options in `README`
- ignore the new `build/` directory

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: operand size mismatch for `push`)*