### PR TITLE
Update assembly ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 
 # Object files and assembly
 src/*.o
-src/*.s
+src/st.s
+src/blib.s
 util/*.o
 
 # Build directories and executables
@@ -11,9 +12,6 @@ src/cg
 src/op
 util/*
 build/
-
-# Symlink to system libraries
-src/sys.s
 
 # Misc temporary files
 *~


### PR DESCRIPTION
## Summary
- keep source assembly files under version control
- ignore generated `st.s` and `blib.s`
- stop ignoring `src/sys.s`

## Testing
- `sh makeall all` *(fails: operand size mismatch for push)*