### PR TITLE
Use bcplc's directory if not installed

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -23,6 +23,10 @@ followed by (as root)
 
     ./makeall install
 
+The build defaults to a 64-bit runtime.  Use ``BITS=32`` with
+``makeall`` or ``make`` in ``src`` to create 32-bit binaries and set
+``CROSS_PREFIX`` as needed for cross builds.
+
 Otherwise, change to the "src" directory. Check that the "sys.s"
 symbolic link points to either "sys_linux.s" or "sys_freebsd.s",
 as appropriate for your system. Enter
@@ -45,9 +49,15 @@ Should you wish to install the compiler somewhere other than
 "/usr/local/lib/bcplc", be sure to change occurrences of this path
 in the compiler sources.
 
-Once the compiler is built and installed, it is possible to build
-and run the "cmpltest" utility in the "util" directory, to verify
-that all is in order. The test should conclude:
+Once the compiler is built you can run the "cmpltest" utility from the
+"util" directory to verify the build.  If ``bcplc`` is not yet installed,
+use the driver in ``src/``.  It automatically finds the runtime files in
+that directory:
+
+    make -C util BC=../src/bcplc test
+
+After installation simply run ``make test`` in ``util``.  The test
+should conclude:
 
     119 TESTS COMPLETED, 0 FAILURE(S)
 

--- a/README
+++ b/README
@@ -49,6 +49,11 @@ Alternatively, you can build directly within ``src/``::
     make -C src
     make -C src install
 
+The Makefiles build a native 64-bit runtime by default.  Specify
+``BITS=32`` when invoking ``makeall`` or ``make`` in ``src`` to create
+32-bit binaries.  Cross builds may also set ``CROSS_PREFIX``
+(for example ``CROSS_PREFIX=i686-linux-gnu-``).
+
 After installation, verify the compiler by running::
 
     bcplc util/cmpltest.bcpl
@@ -95,13 +100,19 @@ code generator and optimizer.  The ``util`` and ``doc`` targets may be
 built from the same build directory.
 
 Ensure the resulting `bcplc` driver is on your `PATH` (or supply a
-`BC` variable pointing to it). Once the compiler is available, enter
-the "util" directory and run
+`BC` variable pointing to it).  If the driver has not yet been
+installed, the tests can be run with the freshly built copy in
+``src/``.  The driver automatically searches its own directory for the
+runtime components, so no installation is required::
+
+    make -C util BC=../src/bcplc test
+
+After installation the shorter
 
     make test
 
-to compile and execute the "cmpltest" suite using the new 64-bit
-runtime system.
+will also compile and execute the "cmpltest" suite using the
+64-bit runtime system.
 
 
 Robert Nordier

--- a/makeall
+++ b/makeall
@@ -42,5 +42,10 @@ done
 
 if [ "$target" = "all" ]; then
     echo "===== util tests ====="
-    (cd util && ${MAKE} test)
+    if command -v bcplc >/dev/null 2>&1; then
+        BC=bcplc
+    else
+        BC=../src/bcplc
+    fi
+    (cd util && ${MAKE} BC=${BC} test)
 fi

--- a/src/bcplc
+++ b/src/bcplc
@@ -9,8 +9,22 @@ error()
     exit 2
 }
 
-prefix=${PREFIX:-/usr/local}
-d=$prefix/lib/bcplc
+# Determine runtime location.  If PREFIX is set use it, otherwise try the
+# directory containing this script before falling back to /usr/local.
+if [ -n "$PREFIX" ]; then
+    prefix="$PREFIX"
+    d="$prefix/lib/bcplc"
+else
+    script_dir=$(cd "$(dirname "$0")" && pwd)
+    if [ -e "$script_dir/st" ]; then
+        d="$script_dir"
+    elif [ -e "$script_dir/../lib/bcplc/st" ]; then
+        d="$script_dir/../lib/bcplc"
+    else
+        prefix=/usr/local
+        d="$prefix/lib/bcplc"
+    fi
+fi
 # Allow callers to override assembler/linker prefix and runtime bitness
 BITS="${BITS:-64}"
 AS="${CROSS_PREFIX:-}as"

--- a/util/Makefile
+++ b/util/Makefile
@@ -1,6 +1,6 @@
 # Makefile for bcplc/util
 
-BC ?= bcplc
+BC ?= $(shell command -v bcplc 2>/dev/null || echo ../src/bcplc)
 BFLAGS ?= -O
 
 all: cmpltest xref gpm


### PR DESCRIPTION
## Summary
- detect runtime files relative to the bcplc script before falling back to `/usr/local`
- clarify util test instructions that the driver finds its own runtime

## Testing
- `BITS=32 ./makeall` *(fails: `Exec format error` for `st`)*