### PR TITLE
Attempt 64-bit runtime fixes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,12 +6,13 @@ PREFIX?=/usr/local
 # CROSS_PREFIX (e.g. ``CROSS_PREFIX=i686-linux-gnu-``).
 BITS?=64
 CROSS_PREFIX?=
+CFLAGS += -DBITS=$(BITS)
 
 ifeq ($(BITS),64)
-  AFLAGS=--64
+  AFLAGS=--64 --defsym BITS=64
   LDMODE=elf_x86_64
 else
-  AFLAGS=--32
+  AFLAGS=--32 --defsym BITS=32
   LDMODE=elf_i386
 endif
 

--- a/src/bcplc
+++ b/src/bcplc
@@ -81,7 +81,7 @@ do
            else
                $d/cg < $ifile | $d/op > $ofile
            fi ;;
-        3) $AS --$BITS -o $ofile $ifile ;;
+        3) $AS --$BITS --defsym BITS=$BITS -o $ofile $ifile ;;
         esac
         ifile=$ofile
         i=$(($i+1))

--- a/src/su.s
+++ b/src/su.s
@@ -2,6 +2,10 @@
 
 // BCPL compiler x86 startup code
 
+.ifndef BITS
+.set BITS,32
+.endif
+
 // The following setting can be changed as desired.
         .set    STKSIZ,0x400000         # BCPL stack size
 
@@ -17,6 +21,68 @@
 
 _start:
         cld
+.if BITS==64
+        mov     $G,%rdi                 # Global vector
+        mov     (%rsp),%ecx             # UNIX argc
+        lea     8(%rsp),%rbx            # UNIX argv
+
+        mov     %rsp,%rax
+        shr     $2,%eax
+        mov     %eax,STACKEND*4(%rdi)   # Define STACKEND
+        sub     $STKSIZ,%rsp
+        mov     %rsp,%rbp               # Set BCPL stack
+        sub     $STKSIZ>>2,%eax
+        mov     %eax,STACKBASE*4(%rdi)  # Define STACKBASE
+
+        mov     %ecx,ARGC*4(%rdi)       # Define ARGC
+        inc     %ecx
+        sub     %ecx,%eax
+        mov     %eax,ARGV*4(%rdi)       # Define ARGV
+        shl     $2,%ecx
+        sub     %rcx,%rsp
+        mov     %rsp,%rdx               # BCPL argv
+
+        xor     %ecx,%ecx
+1:      mov     (%rbx),%esi             # Get UNIX arg
+        test    %esi,%esi               # NULL?
+        jz      1f
+        xor     %eax,%eax
+        mov     %eax,-4(%rsp)           # Zero last cell
+        mov     %rsi,%rdi
+        inc     %ch
+        repne   scasb
+        xor     $255,%cl
+        mov     %ecx,%eax               # String length
+        or      $3,%al
+        inc     %eax
+        sub     %rax,%rsp               # Allocate space
+        mov     %rsp,%rdi
+        mov     %rdi,%rax
+        shr     $2,%eax
+        mov     %eax,(%rdx)             # BCPL pointer
+        mov     %cl,(%rdi)              # Convert string
+        inc     %rdi
+        rep     movsb
+        add     $8,%rbx                 # Bump for next arg
+        add     $4,%rdx
+        jmp     1b
+1:      mov     %esi,(%rdx)
+
+        call    rtinit                  # Runtime setup
+        mov     $G,%rdi                 # Global vector
+
+        mov     ARGV*4(%rdi),%eax
+        inc     %eax
+        mov     (,%rax,4),%ecx
+        jecxz   1f
+        mov     %ecx,%eax
+1:      mov     %eax,PARAM*4(%rdi)      # Define PARAM
+
+        mov     %eax,8(%rbp)            # As arg
+        mov     %rbp,%rcx
+        mov     START*4(%rdi),%eax
+        call    *%rax                   # To BCPL start
+.else
         mov     $G,%edi                 # Global vector
         mov     (%esp),%ecx             # UNIX argc
         lea     4(%esp),%ebx            # UNIX argv
@@ -76,9 +142,16 @@ _start:
         mov     %eax,8(%ebp)            # As arg
         mov     %ebp,%ecx
         call    *START*4(%edi)          # To BCPL start
+.endif
 finish:
         xor     %eax,%eax               # Exit code
 _stop:
+.if BITS==64
+        mov     %eax,%edi
+        call    rtexit                  # Runtime cleanup
+        call    _exit                   # Terminate
+.else
         push    %eax
         call    rtexit                  # Runtime cleanup
         call    _exit                   # Terminate
+.endif


### PR DESCRIPTION
## Summary
- add conditional 64-bit startup code and adjust call sequences
- modify code generator for 64-bit register usage when `BITS==64`

## Testing
- `make -C src clean`
- `make -C src BITS=64`
- `PREFIX=$PWD/local make -C src install`
- `PREFIX=$PWD/local BC=$PWD/src/bcplc make -C util test` *(fails: Segmentation fault)*