### PR TITLE
Install utilities with CMake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,9 +2,12 @@ cmake_minimum_required(VERSION 3.10)
 
 # Build backend programs cg and op
 add_executable(cg cg.c oc.c)
+target_compile_definitions(cg PRIVATE BITS=64)
 add_executable(op op.c pt.c)
+target_compile_definitions(op PRIVATE BITS=64)
 
-set(AS_FLAGS --64)
+# Assemble the runtime in 64-bit mode
+set(AS_FLAGS "--64" "--defsym" "BITS=64")
 set(BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -18,7 +21,17 @@ function(add_asm_object out src)
 endfunction()
 
 add_asm_object(${BUILD_DIR}/su.o ${SRC_DIR}/su.s)
-add_asm_object(${BUILD_DIR}/blib.o ${SRC_DIR}/blib.s)
+set(BLIB_SRC ${SRC_DIR}/blib.s)
+if(BOOTSTRAP)
+    add_custom_command(
+        OUTPUT ${BUILD_DIR}/blib.s
+        COMMAND bash -c "$<TARGET_FILE:cg> < ${SRC_DIR}/blib.O | $<TARGET_FILE:op> > blib.s"
+        WORKING_DIRECTORY ${BUILD_DIR}
+        DEPENDS cg op ${SRC_DIR}/blib.O
+        VERBATIM)
+    set(BLIB_SRC ${BUILD_DIR}/blib.s)
+endif()
+add_asm_object(${BUILD_DIR}/blib.o ${BLIB_SRC})
 add_asm_object(${BUILD_DIR}/global.o ${SRC_DIR}/global.s)
 add_asm_object(${BUILD_DIR}/rt.o ${SRC_DIR}/rt.s)
 add_asm_object(${BUILD_DIR}/sys.o ${SRC_DIR}/sys.s)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -29,6 +29,15 @@ add_bcpl_program(cmpltest)
 add_bcpl_program(xref)
 add_bcpl_program(gpm)
 
+# Install the built utilities alongside the compiler runtime
+install(
+    PROGRAMS
+        ${CMAKE_CURRENT_BINARY_DIR}/cmpltest
+        ${CMAKE_CURRENT_BINARY_DIR}/xref
+        ${CMAKE_CURRENT_BINARY_DIR}/gpm
+    DESTINATION bin
+)
+
 # Optional test target equivalent to "make test" in util
 add_custom_target(test
     COMMAND ./cmpltest


### PR DESCRIPTION
## Summary
- install the cmpltest, xref and gpm utilities via CMake
- ensure the runtime and utilities build correctly in 64‑bit mode

## Testing
- `cmake --build build`
- `cmake --build build --target cmpltest xref gpm`
- `cmake --install . --prefix /tmp/bcpl_install`