### PR TITLE
Set C99 standard for compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(bcplc C)
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
 
 option(BOOTSTRAP "Regenerate st.s using built cg/op" OFF)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
 
 # Build backend programs cg and op
 add_executable(cg cg.c oc.c)


### PR DESCRIPTION
## Summary
- specify C99 for the whole project

## Testing
- `cmake ..`
- `cmake --build . -- VERBOSE=1` *(fails: operand size mismatch for assembly)*