### PR TITLE
Add clang-tidy to reviewdog matrix

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -22,6 +22,7 @@ jobs:
           - { id: "black",       cmd: "black --check --diff ." }
           - { id: "golangci",    cmd: "golangci-lint run --out-format=checkstyle" }
           - { id: "ruff",        cmd: "ruff --output-format=github ." }
+          - { id: "clang-tidy",  cmd: "clang-tidy src/*.c --" }
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
@@ -30,7 +31,7 @@ jobs:
     - name: Install linter runtime deps
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y shellcheck
+        sudo apt-get install -y shellcheck clang-tidy
 
     - name: Run ${{ matrix.linter.id }} & feed Reviewdog
       uses: reviewdog/reviewdog@master


### PR DESCRIPTION
## Summary
- run clang-tidy alongside existing linters
- install clang-tidy in workflow

## Testing
- `pre-commit run --files .github/workflows/reviewdog.yml` *(fails: command not found)*