### PR TITLE
Enable C23 standard and add initial Go port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,12 @@
 cmake_minimum_required(VERSION 3.10)
 project(bcplc C)
-set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD 23)
 set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+if (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
 
 option(BOOTSTRAP "Regenerate st.s using built cg/op" OFF)
 

--- a/README
+++ b/README
@@ -117,3 +117,15 @@ will also compile and execute the "cmpltest" suite using the
 
 Robert Nordier
 www.nordier.com
+
+Experimental Go Port
+====================
+
+The `experimental/bcpl-go` directory contains an in-progress rewrite of
+selected components in Go.  The module targets Go 1.24 and currently
+implements a basic version of the `bcplc` driver.  Tests can be run with
+
+    go test ./experimental/bcpl-go
+
+The port is incomplete but provides a starting point for further
+translation and refactoring in Go.

--- a/experimental/bcpl-go/README.md
+++ b/experimental/bcpl-go/README.md
@@ -1,0 +1,6 @@
+# BCPL-Go
+
+This directory contains an experimental port of the BCPL toolchain written in Go.
+It targets Go 1.24 and aims to replicate the behaviour of the original shell
+driver `src/bcplc` as a first step.  The implementation is incomplete and will
+be extended with additional components of the compiler and runtime.

--- a/experimental/bcpl-go/go.mod
+++ b/experimental/bcpl-go/go.mod
@@ -1,0 +1,4 @@
+module example.com/bcpl-go
+
+go 1.24
+

--- a/experimental/bcpl-go/main.go
+++ b/experimental/bcpl-go/main.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func runtimeDir() string {
+	if p := os.Getenv("PREFIX"); p != "" {
+		return filepath.Join(p, "lib", "bcplc")
+	}
+	exe, err := os.Executable()
+	if err == nil {
+		d := filepath.Dir(exe)
+		if _, err := os.Stat(filepath.Join(d, "st")); err == nil {
+			return d
+		}
+		parent := filepath.Join(d, "..", "lib", "bcplc")
+		if _, err := os.Stat(filepath.Join(parent, "st")); err == nil {
+			return parent
+		}
+	}
+	return filepath.Join("/usr/local", "lib", "bcplc")
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "usage: bcplc [-COSc] [-o output] file ...\n")
+	os.Exit(2)
+}
+
+func main() {
+	var (
+		optC bool
+		optO bool
+		optS bool
+		optc bool
+		out  string
+	)
+	flag.BoolVar(&optC, "C", false, "stop after bcpl->Ocode")
+	flag.BoolVar(&optO, "O", false, "optimise")
+	flag.BoolVar(&optS, "S", false, "stop after Ocode->asm")
+	flag.BoolVar(&optc, "c", false, "stop after assemble")
+	flag.StringVar(&out, "o", "", "output file")
+	flag.Usage = usage
+	flag.Parse()
+
+	cflag := 4
+	if optC {
+		cflag = 1
+	} else if optS {
+		cflag = 2
+	} else if optc {
+		cflag = 3
+	}
+
+	files := flag.Args()
+	if len(files) == 0 {
+		usage()
+	}
+
+	d := runtimeDir()
+	stcmd := filepath.Join(d, "st")
+	cg := filepath.Join(d, "cg")
+	op := filepath.Join(d, "op")
+	asCmd := os.Getenv("CROSS_PREFIX") + "as"
+	ldCmd := os.Getenv("CROSS_PREFIX") + "ld"
+	bits := os.Getenv("BITS")
+	if bits == "" {
+		bits = "64"
+	}
+
+	for _, arg := range files {
+		ext := filepath.Ext(arg)
+		var i int
+		switch ext {
+		case ".b":
+			i = 1
+		case ".O":
+			i = 2
+		case ".s":
+			i = 3
+		case ".o":
+			i = 4
+		default:
+			log.Fatalf("%s: unknown file type", arg)
+		}
+		infile := arg
+		base := arg[:len(arg)-len(ext)]
+		if out == "" {
+			out = base
+		}
+		if i > cflag {
+			log.Fatalf("%s: can't process further", arg)
+		}
+		for i <= 3 && i <= cflag {
+			var outfile string
+			switch i {
+			case 1:
+				outfile = base + ".O"
+				cmd := exec.Command(stcmd)
+				in, err := os.Open(infile)
+				if err != nil {
+					log.Fatal(err)
+				}
+				defer in.Close()
+				outF, err := os.Create(outfile)
+				if err != nil {
+					log.Fatal(err)
+				}
+				cmd.Stdin = in
+				cmd.Stdout = outF
+				if err := cmd.Run(); err != nil {
+					log.Fatal(err)
+				}
+			case 2:
+				outfile = base + ".s"
+				if !optO {
+					cmd := exec.Command(cg)
+					in, err := os.Open(infile)
+					if err != nil {
+						log.Fatal(err)
+					}
+					defer in.Close()
+					outF, err := os.Create(outfile)
+					if err != nil {
+						log.Fatal(err)
+					}
+					cmd.Stdin = in
+					cmd.Stdout = outF
+					if err := cmd.Run(); err != nil {
+						log.Fatal(err)
+					}
+				} else {
+					cmd1 := exec.Command(cg)
+					cmd2 := exec.Command(op)
+					in, err := os.Open(infile)
+					if err != nil {
+						log.Fatal(err)
+					}
+					defer in.Close()
+					outF, err := os.Create(outfile)
+					if err != nil {
+						log.Fatal(err)
+					}
+					r, w := os.Pipe()
+					cmd1.Stdin = in
+					cmd1.Stdout = w
+					cmd2.Stdin = r
+					cmd2.Stdout = outF
+					if err := cmd1.Start(); err != nil {
+						log.Fatal(err)
+					}
+					if err := cmd2.Start(); err != nil {
+						log.Fatal(err)
+					}
+					cmd1.Wait()
+					w.Close()
+					cmd2.Wait()
+				}
+			case 3:
+				outfile = base + ".o"
+				args := []string{"--" + bits, "--defsym", "BITS=" + bits, "-o", outfile, infile}
+				cmd := exec.Command(asCmd, args...)
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				if err := cmd.Run(); err != nil {
+					log.Fatal(err)
+				}
+			}
+			infile = outfile
+			i++
+		}
+	}
+
+	if cflag == 4 {
+		em := "elf_x86_64"
+		if bits != "64" {
+			em = "elf_i386"
+		}
+		args := []string{"-m", em, "-o", out}
+		args = append(args, filepath.Join(d, "su.o"))
+		for _, arg := range files {
+			base := arg[:len(arg)-len(filepath.Ext(arg))]
+			args = append(args, base+".o")
+		}
+		args = append(args, filepath.Join(d, "blib.o"), filepath.Join(d, "global.o"), filepath.Join(d, "rt.o"), filepath.Join(d, "sys.o"))
+		cmd := exec.Command(ldCmd, args...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			log.Fatal(err)
+		}
+	}
+}

--- a/experimental/bcpl-go/main_test.go
+++ b/experimental/bcpl-go/main_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRuntimeDirPrefix(t *testing.T) {
+	tmp := t.TempDir()
+	os.Setenv("PREFIX", tmp)
+	defer os.Unsetenv("PREFIX")
+	got := runtimeDir()
+	want := filepath.Join(tmp, "lib", "bcplc")
+	if got != want {
+		t.Fatalf("runtimeDir()=%q want %q", got, want)
+	}
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
-set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD 23)
 set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
 
 # Build backend programs cg and op
 add_executable(cg cg.c oc.c)


### PR DESCRIPTION
## Summary
- enable C23 across the CMake build and turn on common warnings
- document new experimental Go implementation
- start Go 1.24 module with basic `bcplc` driver implementation and unit test

## Testing
- `go test` *(fails: go.mod requires go >= 1.24)*