### PR TITLE
Add Chicken Scheme port scaffolding and devcontainer

### DIFF
--- a/.devcontainer/hooks/preconfigure
+++ b/.devcontainer/hooks/preconfigure
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Run the main setup script so the dev container has all dependencies
+cd "$(dirname "$0")/../.."
+./setup.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
         else
           sh makeall all
         fi
+    - name: Build Chicken Scheme port
+      run: |
+        if command -v csc >/dev/null 2>&1; then
+          csc -o chicken/bcplc-chicken chicken/main.scm
+        fi
     - name: Test utilities
       run: |
         if [ "${{ matrix.bits }}" = "32" ]; then

--- a/README
+++ b/README
@@ -114,6 +114,12 @@ After installation the shorter
 will also compile and execute the "cmpltest" suite using the
 64-bit runtime system.
 
+Experimental Chicken Scheme Port
+-------------------------------
+An early experiment using [Chicken Scheme](https://call-cc.org/) lives in
+the `chicken/` directory.  It is not built by default and currently
+contains only stubs.  Consult `chicken/README.md` for more information.
+
 
 Robert Nordier
 www.nordier.com

--- a/chicken/README.md
+++ b/chicken/README.md
@@ -1,0 +1,15 @@
+# Experimental Chicken Scheme Port
+
+This directory contains an experimental port of the BCPL compiler to [Chicken Scheme](https://call-cc.org/). The goal is to eventually reimplement parts of the runtime using Scheme in order to aid experimentation and prototyping.  Nothing here is built or installed by default.
+
+## Building
+
+The examples are intended to be built with `csc`, the Chicken Scheme compiler. For instance:
+
+```sh
+csc -o bcplc-chicken main.scm
+```
+
+## Status
+
+This port is under heavy development. The files currently present are only stubs meant to establish the directory structure.

--- a/chicken/main.scm
+++ b/chicken/main.scm
@@ -1,0 +1,3 @@
+;; Experimental Chicken Scheme entry point for BCPL compiler port
+(display "BCPL Chicken port placeholder")
+(newline)

--- a/setup.sh
+++ b/setup.sh
@@ -49,7 +49,8 @@ done
 pip3 install --no-cache-dir \
   tensorflow-cpu jax jaxlib \
   tensorflow-model-optimization mlflow onnxruntime-tools \
-  atheris
+  atheris \
+  black ruff pylint mypy pytest pytest-cov hypothesis
 
 # QEMU emulation for foreign binaries
 for pkg in \


### PR DESCRIPTION
## Summary
- scaffold `chicken/` for an experimental port
- document the experimental port in `README`
- add `black`, `ruff`, `pylint`, `mypy`, `pytest` and related tools to the setup script
- add devcontainer `preconfigure` hook invoking `setup.sh`
- compile the Chicken Scheme sample in CI

## Testing
- `make -C src` *(fails: invalid instruction suffix for `call`)*