### PR TITLE
Enable cross-arch CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,24 @@ set(CMAKE_C_STANDARD 23)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
 
+# Allow selection of runtime bitness.  The historical runtime is 32 bit
+# but the repository defaults to a 64 bit build.  A ``BITS`` cache
+# variable mirrors the Makefiles and can be overridden on the command
+# line with ``-DBITS=32``.
+set(BITS "64" CACHE STRING "Target word size" )
+set_property(CACHE BITS PROPERTY STRINGS 32 64)
+
+# Optional prefix for assembler/linker tools when cross compiling.  The
+# environment variable of the same name is used as the default to
+# maintain compatibility with the traditional Makefiles and driver
+# script.
+set(CROSS_PREFIX "$ENV{CROSS_PREFIX}" CACHE STRING "Cross compilation tool prefix")
+
 if (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
     add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-option(BOOTSTRAP "Regenerate st.s using built cg/op" OFF)
+option(BOOTSTRAP "Regenerate st.s using built cg/op" ON)
 
 add_subdirectory(src)
 add_subdirectory(util)

--- a/INSTALL
+++ b/INSTALL
@@ -24,8 +24,9 @@ followed by (as root)
     ./makeall install
 
 The build defaults to a 64-bit runtime.  Use ``BITS=32`` with
-``makeall`` or ``make`` in ``src`` to create 32-bit binaries and set
-``CROSS_PREFIX`` as needed for cross builds.
+``makeall`` or ``make`` in ``src`` (or ``-DBITS=32`` when using CMake)
+to create 32-bit binaries and set ``CROSS_PREFIX`` as needed for cross
+builds.
 
 Otherwise, change to the "src" directory. Check that the "sys.s"
 symbolic link points to either "sys_linux.s" or "sys_freebsd.s",

--- a/README
+++ b/README
@@ -49,17 +49,19 @@ Alternatively, you can build directly within ``src/``::
     make -C src
     make -C src install
 
-The Makefiles build a native 64-bit runtime by default.  Specify
-``BITS=32`` when invoking ``makeall`` or ``make`` in ``src`` to create
+The Makefiles and CMake build files default to a 64-bit runtime.
+Specify ``BITS=32`` (or ``-DBITS=32`` when using CMake) to build
 32-bit binaries.  Cross builds may also set ``CROSS_PREFIX``
-(for example ``CROSS_PREFIX=i686-linux-gnu-``).
+(for example ``CROSS_PREFIX=i686-linux-gnu-``) to select alternate
+assembler and linker commands.
 
 After installation, verify the compiler by running::
 
     bcplc util/cmpltest.bcpl
 
-The runtime components now build as native 64-bit executables.
-Support for ``qemu-i386`` is therefore no longer required.
+By default the runtime is 64 bit, so running under ``qemu-i386`` is no
+longer required.  A 32-bit build remains available for older
+environments via ``BITS=32`` or ``-DBITS=32``.
 
 This should print::
 
@@ -95,9 +97,10 @@ looks like::
     cmake --build build
     cmake --install build
 
-Pass ``-DBOOTSTRAP=ON`` to regenerate ``st.s`` using the freshly built
-code generator and optimizer.  The ``util`` and ``doc`` targets may be
-built from the same build directory.
+The CMake build regenerates ``st.s`` using the freshly built code
+generator by default.  Set ``-DBOOTSTRAP=OFF`` to skip this step.  The
+``util`` and ``doc`` targets may be built from the same build
+directory.
 
 Ensure the resulting `bcplc` driver is on your `PATH` (or supply a
 `BC` variable pointing to it).  If the driver has not yet been

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,19 +5,28 @@ set(CMAKE_C_EXTENSIONS OFF)
 
 # Build backend programs cg and op
 add_executable(cg cg.c oc.c)
-target_compile_definitions(cg PRIVATE BITS=64)
+target_compile_definitions(cg PRIVATE BITS=${BITS})
 add_executable(op op.c pt.c)
-target_compile_definitions(op PRIVATE BITS=64)
+target_compile_definitions(op PRIVATE BITS=${BITS})
 
-# Assemble the runtime in 64-bit mode
-set(AS_FLAGS "--64" "--defsym" "BITS=64")
+# Assemble the runtime
+if(BITS STREQUAL "64")
+    set(AS_FLAGS "--64" "--defsym" "BITS=64")
+    set(LD_MODE "elf_x86_64")
+else()
+    set(AS_FLAGS "--32" "--defsym" "BITS=32")
+    set(LD_MODE "elf_i386")
+endif()
+
+set(AS "${CROSS_PREFIX}as")
+set(LD "${CROSS_PREFIX}ld")
 set(BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 function(add_asm_object out src)
     add_custom_command(
         OUTPUT ${out}
-        COMMAND as ${AS_FLAGS} -o ${out} ${src}
+        COMMAND ${AS} ${AS_FLAGS} -o ${out} ${src}
         DEPENDS ${src}
         WORKING_DIRECTORY ${BUILD_DIR}
         VERBATIM)
@@ -52,7 +61,7 @@ endif()
 
 add_custom_command(
     OUTPUT ${BUILD_DIR}/st.o
-    COMMAND as ${AS_FLAGS} -o st.o ${ST_SRC}
+    COMMAND ${AS} ${AS_FLAGS} -o st.o ${ST_SRC}
     DEPENDS ${ST_SRC}
     WORKING_DIRECTORY ${BUILD_DIR}
     VERBATIM)
@@ -67,7 +76,7 @@ set(RUNTIME_OBJS
 
 add_custom_command(
     OUTPUT ${BUILD_DIR}/st
-    COMMAND ld -m elf_x86_64 -o st ${RUNTIME_OBJS}
+    COMMAND ${LD} -m ${LD_MODE} -o st ${RUNTIME_OBJS}
     DEPENDS ${RUNTIME_OBJS}
     WORKING_DIRECTORY ${BUILD_DIR}
     VERBATIM)


### PR DESCRIPTION
## Summary
- add `BITS` and `CROSS_PREFIX` cache variables
- default bootstrap regeneration of `st.s`
- adjust src build to respect `BITS` and use cross tools
- document new options and defaults in README and INSTALL

## Testing
- `cmake ..`
- `cmake --build .`
- `cmake --build . --target test` *(fails: `./cmpltest` not found)*