### PR TITLE
Add Codex configure script for debugging tools

### DIFF
--- a/.codex/configure.sh
+++ b/.codex/configure.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+apt-get update -y
+apt-get install -y gdb strace valgrind
+
+exit 0


### PR DESCRIPTION
## Summary
- add `.codex/configure.sh` to install debugging utilities like gdb, strace, and valgrind

## Testing
- `./makeall` *(fails: segmentation fault)*
- `make -C util test` *(fails: segmentation fault)*