### PR TITLE
Replace opcode macros with typed enum

### DIFF
--- a/src/cg.c
+++ b/src/cg.c
@@ -86,7 +86,7 @@ static int labno;          /* label counter */
 static int loff;           /* label offset */
 static int ch;             /* last char read */
 
-static int  gencode(void);
+static ocode_op gencode(void);
 static void load(int, int);
 static void save(int, int);
 static void force(int);
@@ -104,7 +104,7 @@ static void error(const char *, ...);
 
 int main(void)
 {
-    int op;
+    ocode_op op;
 
     do
     {
@@ -116,9 +116,10 @@ int main(void)
     return 0;
 }
 
-static int gencode(void)
+static ocode_op gencode(void)
 {
-    int ro, op, s1, s2, s3, sn;
+    int ro, s1, s2, s3, sn;
+    ocode_op op;
 
     dt = sp = lp = ro = 0;
     emit(".text");

--- a/src/oc.h
+++ b/src/oc.h
@@ -2,76 +2,78 @@
 /* Copyright (c) 2012 Robert Nordier. All rights reserved. */
 
 /* OCODE operators */
-#define S_TRUE      4
-#define S_FALSE     5
-#define S_RV        8
-#define S_FNAP      10
-#define S_MULT      11
-#define S_DIV       12
-#define S_REM       13
-#define S_PLUS      14
-#define S_MINUS     15
-#define S_QUERY     16
-#define S_NEG       17
-#define S_ABS       19
-#define S_EQ        20
-#define S_NE        21
-#define S_LS        22
-#define S_GR        23
-#define S_LE        24
-#define S_GE        25
-#define S_NOT       30
-#define S_LSHIFT    31
-#define S_RSHIFT    32
-#define S_LOGAND    33
-#define S_LOGOR     34
-#define S_EQV       35
-#define S_NEQV      36
-#define S_COND      37
-#define S_LP        40
-#define S_LG        41
-#define S_LN        42
-#define S_LSTR      43
-#define S_LL        44
-#define S_LLP       45
-#define S_LLG       46
-#define S_LLL       47
-#define S_NEEDS     48
-#define S_SECTION   49
-#define S_RTAP      51
-#define S_GOTO      52
-#define S_RETURN    67
-#define S_FINISH    68
-#define S_SWITCHON  70
-#define S_GLOBAL    76
-#define S_SP        80
-#define S_SG        81
-#define S_SL        82
-#define S_STIND     83
-#define S_JUMP      85
-#define S_JT        86
-#define S_JF        87
-#define S_ENDFOR    88
-#define S_BLAB      89
-#define S_LAB       90
-#define S_STACK     91
-#define S_STORE     92
-#define S_RSTACK    93
-#define S_ENTRY     94
-#define S_SAVE      95
-#define S_FNRN      96
-#define S_RTRN      97
-#define S_RES       98
-#define S_RESLAB    99
-#define S_DATALAB   100
-#define S_ITEML     101
-#define S_ITEMN     102
-#define S_ENDPROC   103
-#define S_END       104
-#define S_GETBYTE   120
-#define S_PUTBYTE   121
+typedef enum ocode_op : int {
+    S_TRUE      = 4,
+    S_FALSE     = 5,
+    S_RV        = 8,
+    S_FNAP      = 10,
+    S_MULT      = 11,
+    S_DIV       = 12,
+    S_REM       = 13,
+    S_PLUS      = 14,
+    S_MINUS     = 15,
+    S_QUERY     = 16,
+    S_NEG       = 17,
+    S_ABS       = 19,
+    S_EQ        = 20,
+    S_NE        = 21,
+    S_LS        = 22,
+    S_GR        = 23,
+    S_LE        = 24,
+    S_GE        = 25,
+    S_NOT       = 30,
+    S_LSHIFT    = 31,
+    S_RSHIFT    = 32,
+    S_LOGAND    = 33,
+    S_LOGOR     = 34,
+    S_EQV       = 35,
+    S_NEQV      = 36,
+    S_COND      = 37,
+    S_LP        = 40,
+    S_LG        = 41,
+    S_LN        = 42,
+    S_LSTR      = 43,
+    S_LL        = 44,
+    S_LLP       = 45,
+    S_LLG       = 46,
+    S_LLL       = 47,
+    S_NEEDS     = 48,
+    S_SECTION   = 49,
+    S_RTAP      = 51,
+    S_GOTO      = 52,
+    S_RETURN    = 67,
+    S_FINISH    = 68,
+    S_SWITCHON  = 70,
+    S_GLOBAL    = 76,
+    S_SP        = 80,
+    S_SG        = 81,
+    S_SL        = 82,
+    S_STIND     = 83,
+    S_JUMP      = 85,
+    S_JT        = 86,
+    S_JF        = 87,
+    S_ENDFOR    = 88,
+    S_BLAB      = 89,
+    S_LAB       = 90,
+    S_STACK     = 91,
+    S_STORE     = 92,
+    S_RSTACK    = 93,
+    S_ENTRY     = 94,
+    S_SAVE      = 95,
+    S_FNRN      = 96,
+    S_RTRN      = 97,
+    S_RES       = 98,
+    S_RESLAB    = 99,
+    S_DATALAB   = 100,
+    S_ITEML     = 101,
+    S_ITEMN     = 102,
+    S_ENDPROC   = 103,
+    S_END       = 104,
+    S_GETBYTE   = 120,
+    S_PUTBYTE   = 121
+} ocode_op;
 
-#define OPMAX       121
+enum { OPMAX = S_PUTBYTE };
 
 #define OPATTR      4
 


### PR DESCRIPTION
## Summary
- define `ocode_op` enum in oc.h and remove `#define` opcodes
- update cg.c to use the new `ocode_op` type
- keep `OPMAX` as a constant equal to `S_PUTBYTE`

## Testing
- `make -C src CC=clang`
