### PR TITLE
Update error() to use [[noreturn]]

### DIFF
--- a/src/cg.c
+++ b/src/cg.c
@@ -101,7 +101,7 @@ static void emit(const char *, ...);
 static char *label(int);
 static int  rdop(int);
 static int  rdn(void);
-static void error(const char *, ...);
+[[noreturn]] static void error(const char *, ...);
 
 /*
  * Helper to append formatted data to a buffer while tracking the
@@ -762,7 +762,7 @@ static int rdn(void)
     return neg ? -n : n;
 }
 
-static void error(const char *msg, ...)
+[[noreturn]] static void error(const char *msg, ...)
 {
     va_list ap;
 


### PR DESCRIPTION
## Summary
- mark `error` as `[[noreturn]]` in `cg.c`

## Testing
- `CC=clang cmake -S . -B build`
- `cmake --build build`