### PR TITLE
derive WORDSZ from BITS

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -30,7 +30,8 @@ before building.
 The build defaults to a 64-bit runtime.  Use ``BITS=32`` with
 ``scripts/makeall.sh`` or ``make`` in ``src`` (or ``-DBITS=32`` when using CMake)
 to create 32-bit binaries and set ``CROSS_PREFIX`` as needed for cross
-builds.
+builds.  ``WORDSZ`` is derived from ``BITS`` so a 64-bit runtime uses
+8-byte words while a 32-bit runtime uses 4-byte words.
 
 Otherwise, change to the "src" directory. Check that the "sys.s"
 symbolic link points to either "sys_linux.s" or "sys_freebsd.s",

--- a/README
+++ b/README
@@ -57,7 +57,9 @@ The Makefiles and CMake build files default to a 64-bit runtime.
 Specify ``BITS=32`` (or ``-DBITS=32`` when using CMake) to build
 32-bit binaries.  Cross builds may also set ``CROSS_PREFIX``
 (for example ``CROSS_PREFIX=i686-linux-gnu-``) to select alternate
-assembler and linker commands.
+assembler and linker commands.  The BCPL word size (``WORDSZ``)
+is selected automatically from ``BITS`` and will be 8 bytes for
+a 64-bit build, 4 bytes for 32 bit and 2 bytes for 16 bit.
 
 After installation, verify the compiler by running::
 


### PR DESCRIPTION
## Summary
- derive `WORDSZ` and `WORD_SHIFT` from the `BITS` build setting
- use these constants for pointer arithmetic in the code generator
- document that WORDSZ depends on BITS in README and INSTALL

## Testing
- `make -C src` *(fails: unrecognized option '-std=c23')*
- `make -C tools test` *(fails: /usr/local/lib/bcplc/st not found)*