### PR TITLE
Document 16-bit build support

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -14,6 +14,9 @@ will be found useful should you wish to test the compiler once that
 has been built and installed. The "docs" directory contains
 relevant documentation.
 
+Optionally run ``./setup.sh`` as root to install build dependencies
+including QEMU, numerous cross‑compilers and the IA‑16 toolchain.
+
 To build and install the compiler in automated fashion (assuming
 you're on a supported platform), try
 
@@ -29,8 +32,12 @@ before building.
 
 The build defaults to a 64-bit runtime.  Use ``BITS=32`` with
 ``scripts/makeall.sh`` or ``make`` in ``src`` (or ``-DBITS=32`` when using CMake)
-to create 32-bit binaries and set ``CROSS_PREFIX`` as needed for cross
-builds.
+to create 32-bit binaries.  Setting ``BITS=16`` builds an experimental
+16-bit runtime; this requires the IA‑16 toolchain installed by
+``setup.sh``.  Cross builds may set ``CROSS_PREFIX`` as needed.  A typical
+16-bit build uses::
+
+    make -C src BITS=16 CROSS_PREFIX=ia16-elf-
 
 Otherwise, change to the "src" directory. Check that the "sys.s"
 symbolic link points to either "sys_linux.s" or "sys_freebsd.s",

--- a/README
+++ b/README
@@ -34,8 +34,9 @@ Building
 Before building you may install a comprehensive cross‑compilation
 environment by running ``./setup.sh`` as root.  The script configures
 package repositories for multiple architectures and installs toolchains
-and emulators such as ``qemu`` to enable execution of foreign binaries,
-including 16‑bit and 32‑bit x86 programs.  This is optional for a
+and emulators such as ``qemu`` to enable execution of foreign binaries.
+It also fetches the IA‑16 GCC cross‑compiler, ``protoc`` and numerous
+other development utilities.  Installing the script is optional for a
 straightforward native build but recommended when targeting older or
 non‑native platforms.
 
@@ -55,9 +56,14 @@ Alternatively, you can build directly within ``src/``::
 
 The Makefiles and CMake build files default to a 64-bit runtime.
 Specify ``BITS=32`` (or ``-DBITS=32`` when using CMake) to build
-32-bit binaries.  Cross builds may also set ``CROSS_PREFIX``
+32-bit binaries or ``BITS=16`` to target an experimental 16-bit
+runtime.  Cross builds may also set ``CROSS_PREFIX``
 (for example ``CROSS_PREFIX=i686-linux-gnu-``) to select alternate
-assembler and linker commands.
+assembler and linker commands.  The IA‑16 toolchain installed by
+``setup.sh`` exposes the prefix ``ia16-elf-`` so a full 16-bit build
+looks like::
+
+    make -C src BITS=16 CROSS_PREFIX=ia16-elf-
 
 After installation, verify the compiler by running::
 
@@ -65,7 +71,9 @@ After installation, verify the compiler by running::
 
 By default the runtime is 64 bit, so running under ``qemu-i386`` is no
 longer required.  A 32-bit build remains available for older
-environments via ``BITS=32`` or ``-DBITS=32``.
+environments via ``BITS=32`` or ``-DBITS=32``.  ``BITS=16`` produces
+a 16-bit binary suitable for DOS environments or emulators such as
+``dosemu`` or ``qemu-system-i386``.
 
 This should print::
 


### PR DESCRIPTION
## Summary
- document the optional setup script details
- note `BITS=16` builds
- show how to cross‑compile for IA-16

## Testing
- `make -C src CC=clang`
- `make -C tools BC=../src/bcplc test` *(fails: Segmentation fault)*