### PR TITLE
Default to clang for build

### DIFF
--- a/README
+++ b/README
@@ -44,9 +44,10 @@ To build the compiler from the top-level directory, run::
     ./scripts/makeall.sh
     ./scripts/makeall.sh install
 
-The build now requires the Clang compiler with C23 support. Ensure
-`clang` is available in your `PATH` or specify `CC=clang` when
-invoking the Makefiles.
+The build now requires the Clang compiler with C23 support.  The
+Makefile selects ``clang`` by default, so no extra arguments are
+needed.  Use ``CC=gcc`` or another compiler only if it understands
+C23.
 
 Alternatively, you can build directly within ``src/``::
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,8 @@ PREFIX?=/usr/local
 # CROSS_PREFIX (e.g. ``CROSS_PREFIX=i686-linux-gnu-``).
 BITS?=64
 CROSS_PREFIX?=
-CC ?= clang
+# Clang is required for the C23 sources.  Use CC=foo to override.
+CC = clang
 CFLAGS += -std=c23 -Wall -Wextra -Wpedantic
 CFLAGS += -DBITS=$(BITS)
 


### PR DESCRIPTION
## Summary
- default to clang in src/Makefile so builds pick up a C23 capable compiler
- clarify README about clang being selected by default

## Testing
- `make -C src`
- `make -C tools BC=../src/bcplc test` *(fails: Segmentation fault)*