### PR TITLE
Add toolchain dependency check script

### DIFF
--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -1,0 +1,35 @@
+#!/bin/sh -e
+
+# Check required build tools before running makeall.sh
+# Verifies clang, as, ld and the cross toolchain specified by
+# CROSS_PREFIX and BITS.
+
+BITS=${BITS:-64}
+CROSS_PREFIX=${CROSS_PREFIX:-}
+
+missing=0
+check_tool() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Missing required tool: $1" >&2
+        missing=1
+    fi
+}
+
+# Base toolchain
+check_tool clang
+check_tool as
+check_tool ld
+
+# Cross toolchain if requested
+if [ -n "$CROSS_PREFIX" ]; then
+    check_tool "${CROSS_PREFIX}clang"
+    check_tool "${CROSS_PREFIX}as"
+    check_tool "${CROSS_PREFIX}ld"
+fi
+
+if [ "$missing" -ne 0 ]; then
+    echo "One or more required tools are missing." >&2
+    exit 1
+fi
+
+exit 0

--- a/scripts/makeall.sh
+++ b/scripts/makeall.sh
@@ -5,6 +5,10 @@
 DIRS="src docs"
 MAKE=make
 
+# Verify required tools before proceeding
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+"$script_dir/check-deps.sh"
+
 # Initialize
 if test $# -gt 1; then
     echo "usage: makeall [target]" 1>&2


### PR DESCRIPTION
## Summary
- add `scripts/check-deps.sh` for verifying build tools
- call dependency check from `scripts/makeall.sh` before building

## Testing
- `./scripts/check-deps.sh`
- `BITS=64 CROSS_PREFIX=foo- ./scripts/check-deps.sh` (fails as expected)
- `sh scripts/makeall.sh clean`