### PR TITLE
Add requirements section

### DIFF
--- a/README
+++ b/README
@@ -28,6 +28,22 @@ command line arguments and error reporting. Some documentation
 that formed part of the original BCPL distribution tape is also
 included, as are a few utility programs.
 
+Requirements
+============
+
+The compiler relies on a standard set of development tools.  Ensure at
+least the following packages are available::
+
+    clang
+    make
+    cmake
+    binutils
+    gcc-multilib
+    qemu
+
+Running ``./setup.sh`` installs all of the above along with a full
+cross‑compilation environment and the IA‑16 toolchain.
+
 Building
 ========
 


### PR DESCRIPTION
## Summary
- document required build packages in README
- mention `setup.sh` installs them and the IA-16 toolchain

## Testing
- `make -C src cg op st`
- `make -C tools BC=../src/bcplc test` *(fails: Segmentation fault)*