### PR TITLE
Fix build validation for Linux

### DIFF
--- a/src/arch/arm32/runtime_arm32.c
+++ b/src/arch/arm32/runtime_arm32.c
@@ -3,7 +3,7 @@
  * Optimized for ARMv7-A and ARMv8-A (32-bit mode)
  */
 
-#include "../runtime/bcpl_runtime.h"
+#include "bcpl_runtime.h"
 #include <stdint.h>
 #include <sys/mman.h>
 

--- a/src/arch/x86_16/runtime_x86_16.c
+++ b/src/arch/x86_16/runtime_x86_16.c
@@ -3,7 +3,7 @@
  * Optimized for 16-bit x86 architecture - legacy support
  */
 
-#include "../runtime/bcpl_runtime.h"
+#include "bcpl_runtime.h"
 #include <stdint.h>
 
 #ifdef BCPL_X86_16

--- a/src/arch/x86_32/runtime_x86_32.c
+++ b/src/arch/x86_32/runtime_x86_32.c
@@ -3,7 +3,7 @@
  * Optimized for 32-bit x86 architecture
  */
 
-#include "../runtime/bcpl_runtime.h"
+#include "bcpl_runtime.h"
 #include <stdint.h>
 #include <sys/mman.h>
 

--- a/src/arch/x86_64/runtime_x86_64.c
+++ b/src/arch/x86_64/runtime_x86_64.c
@@ -3,7 +3,7 @@
  * Optimized for x86-64 architecture with SSE/AVX support
  */
 
-#include "../runtime/bcpl_runtime.h"
+#include "bcpl_runtime.h"
 #include <cpuid.h>
 #include <stdint.h>
 #include <sys/mman.h>

--- a/src/include/platform/generic.h
+++ b/src/include/platform/generic.h
@@ -1,0 +1,32 @@
+#ifndef BCPL_PLATFORM_GENERIC_H
+#define BCPL_PLATFORM_GENERIC_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+const char *bcpl_platform_name(void);
+const char *bcpl_temp_dir(void);
+const char *bcpl_exe_extension(void);
+const char *bcpl_lib_extension(void);
+char bcpl_path_separator(void);
+char bcpl_path_list_separator(void);
+int bcpl_file_executable(const char *path);
+long bcpl_file_size(const char *path);
+int bcpl_mkdir(const char *path);
+char *bcpl_getcwd(char *buf, size_t size);
+int bcpl_chdir(const char *path);
+int bcpl_platform_init(void);
+void bcpl_platform_cleanup(void);
+int bcpl_cpu_count(void);
+size_t bcpl_page_size(void);
+uint64_t bcpl_nano_time(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BCPL_PLATFORM_GENERIC_H

--- a/src/include/platform/linux.h
+++ b/src/include/platform/linux.h
@@ -1,0 +1,32 @@
+#ifndef BCPL_PLATFORM_LINUX_H
+#define BCPL_PLATFORM_LINUX_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+const char *bcpl_platform_name(void);
+const char *bcpl_temp_dir(void);
+const char *bcpl_exe_extension(void);
+const char *bcpl_lib_extension(void);
+char bcpl_path_separator(void);
+char bcpl_path_list_separator(void);
+int bcpl_file_executable(const char *path);
+long bcpl_file_size(const char *path);
+int bcpl_mkdir(const char *path);
+char *bcpl_getcwd(char *buf, size_t size);
+int bcpl_chdir(const char *path);
+int bcpl_platform_init(void);
+void bcpl_platform_cleanup(void);
+int bcpl_cpu_count(void);
+size_t bcpl_page_size(void);
+uint64_t bcpl_nano_time(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BCPL_PLATFORM_LINUX_H

--- a/src/platform/generic.c
+++ b/src/platform/generic.c
@@ -13,7 +13,12 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/mman.h>
 #include <unistd.h>
+
+#include "../include/bcpl_types.h"
+#include "../include/platform.h"
+#include "../include/universal_platform.h"
 
 #ifdef BCPL_PLATFORM_GENERIC
 

--- a/src/platform/linux.c
+++ b/src/platform/linux.c
@@ -13,7 +13,14 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/mman.h>
 #include <unistd.h>
+#include <stdint.h>
+#include <time.h>
+
+#include "../include/bcpl_types.h"
+#include "../include/platform.h"
+#include "../include/universal_platform.h"
 
 #ifdef BCPL_PLATFORM_LINUX
 
@@ -107,6 +114,70 @@ int bcpl_chdir(const char *path) {
   return chdir(path);
 }
 
+// =============================================================================
+// FILE OPERATIONS
+// =============================================================================
+
+bcpl_file_handle_t *bcpl_platform_fopen(const char *filename, char mode,
+                                        bool binary) {
+  bcpl_file_handle_t *handle = malloc(sizeof(bcpl_file_handle_t));
+  if (!handle)
+    return NULL;
+
+  const char *fmode = NULL;
+  switch (mode) {
+  case 'r':
+    fmode = binary ? "rb" : "r";
+    break;
+  case 'w':
+    fmode = binary ? "wb" : "w";
+    break;
+  case 'a':
+    fmode = binary ? "ab" : "a";
+    break;
+  default:
+    free(handle);
+    return NULL;
+  }
+
+  handle->native_handle = fopen(filename, fmode);
+  if (!handle->native_handle) {
+    free(handle);
+    return NULL;
+  }
+
+  handle->flags = 0;
+  handle->buffer = NULL;
+  handle->buffer_size = 0;
+  handle->is_binary = binary;
+  return handle;
+}
+
+int bcpl_platform_fclose(bcpl_file_handle_t *handle) {
+  if (!handle)
+    return -1;
+  int result = 0;
+  if (handle->native_handle)
+    result = fclose(handle->native_handle);
+  free(handle->buffer);
+  free(handle);
+  return result;
+}
+
+int bcpl_platform_fgetc(bcpl_file_handle_t *handle) {
+  if (!handle || !handle->native_handle)
+    return -1;
+  return fgetc(handle->native_handle);
+}
+
+int bcpl_platform_fputc(int ch, bcpl_file_handle_t *handle) {
+  if (!handle || !handle->native_handle)
+    return -1;
+  return fputc(ch, handle->native_handle);
+}
+
+int bcpl_platform_remove(const char *filename) { return unlink(filename); }
+
 /*
  * Platform-specific initialization
  */
@@ -148,6 +219,111 @@ uint64_t bcpl_nano_time(void) {
     return 0;
   }
   return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+}
+
+// =============================================================================
+// UNIVERSAL PLATFORM INTERFACE IMPLEMENTATION
+// =============================================================================
+
+void *bcpl_platform_aligned_alloc(size_t size, size_t alignment) {
+  void *ptr = NULL;
+  if (posix_memalign(&ptr, alignment, size) == 0)
+    return ptr;
+  return NULL;
+}
+
+void bcpl_platform_aligned_free(void *ptr) {
+  free(ptr);
+}
+
+size_t bcpl_platform_get_page_size(void) {
+  return bcpl_page_size();
+}
+
+void *bcpl_platform_alloc(size_t size) {
+  return malloc(size);
+}
+
+void bcpl_platform_free(void *ptr) {
+  free(ptr);
+}
+
+void *bcpl_platform_alloc_pages(size_t size) {
+  size_t page_size = bcpl_page_size();
+  size = (size + page_size - 1) & ~(page_size - 1);
+  void *mem = mmap(NULL, size, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  return mem == MAP_FAILED ? NULL : mem;
+}
+
+void bcpl_platform_free_pages(void *ptr, size_t size) {
+  if (!ptr)
+    return;
+  size_t page_size = bcpl_page_size();
+  size = (size + page_size - 1) & ~(page_size - 1);
+  munmap(ptr, size);
+}
+
+uint64_t bcpl_platform_get_timestamp(void) {
+  return bcpl_nano_time();
+}
+
+void bcpl_platform_sleep(uint64_t nanoseconds) {
+  struct timespec ts;
+  ts.tv_sec = nanoseconds / 1000000000ULL;
+  ts.tv_nsec = nanoseconds % 1000000000ULL;
+  nanosleep(&ts, NULL);
+}
+
+uint64_t bcpl_platform_get_time_ns(void) {
+  return bcpl_nano_time();
+}
+
+void bcpl_platform_sleep_ms(uint32_t milliseconds) {
+  bcpl_platform_sleep((uint64_t)milliseconds * 1000000ULL);
+}
+
+int bcpl_platform_get_cpu_count(void) {
+  return bcpl_cpu_count();
+}
+
+int bcpl_platform_get_last_error(void) {
+  return errno;
+}
+
+const char *bcpl_platform_getenv(const char *name) {
+  return getenv(name);
+}
+
+void bcpl_platform_print_stacktrace(FILE *file) {
+  (void)file;
+  fprintf(stderr, "Stack trace not available on Linux\n");
+}
+
+void bcpl_platform_memcpy(void *dest, const void *src, size_t size) {
+  memcpy(dest, src, size);
+}
+
+void bcpl_platform_memset(void *dest, int value, size_t size) {
+  memset(dest, value, size);
+}
+
+int bcpl_platform_memcmp(const void *ptr1, const void *ptr2, size_t size) {
+  return memcmp(ptr1, ptr2, size);
+}
+
+_Noreturn void bcpl_platform_exit(int code) {
+  exit(code);
+}
+
+bcpl_cpu_features_t bcpl_platform_get_cpu_features(void) {
+  bcpl_cpu_features_t features = {0};
+  strncpy(features.arch_name, "x86_64", sizeof(features.arch_name) - 1);
+  features.core_count = bcpl_cpu_count();
+  features.has_simd = true;
+  features.has_aes = false;
+  features.feature_flags = BCPL_CPU_FEATURE_SSE2;
+  return features;
 }
 
 #endif /* BCPL_PLATFORM_LINUX */

--- a/tests/test_performance.c
+++ b/tests/test_performance.c
@@ -5,6 +5,7 @@
  * @date 2025
  */
 
+#define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
## Summary
- repair validate_build.sh repo path and output checks
- add linux and generic platform headers
- implement missing universal_platform functions for Linux
- fix includes in arch runtime sources
- support POSIX clock in performance tests

## Testing
- `bash scripts/validate_build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6860dde0da208331a4fbb19f22921694