### PR TITLE
Add docs/tests CMakeLists and update build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,15 @@ include(CompilerFlags)         # Common compiler options
 include(Options)               # Optional tooling flags
 include(PlatformConfig)        # Platform-specific helpers
 
+# Optionally build the unit tests
+option(ENABLE_TESTS "Build BCPL test suite" ON)
+
 # -----------------------------------------------------------------------------
 # Subdirectories
 # -----------------------------------------------------------------------------
 add_subdirectory(src)
-add_subdirectory(tests)
+if(ENABLE_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
 add_subdirectory(docs)
-
-enable_testing()

--- a/cmake/CompilerFlags.cmake
+++ b/cmake/CompilerFlags.cmake
@@ -28,23 +28,40 @@ set(BCPL_BASE_C_FLAGS
 #   RelWithDebInfo : moderate optimization (O2) with debug symbols (g)
 #   Release        : optimized build (O2) without debug info
 # -----------------------------------------------------------------------------
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+# Normalize build type for single-config generators
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+    # Default to Release if build type is unspecified
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
+endif()
+
+string(TOUPPER "${CMAKE_BUILD_TYPE}" _BCPL_BUILD_TYPE)
+
+if(CMAKE_CONFIGURATION_TYPES)
+    # Multi-config generator: use generator expressions
     list(APPEND BCPL_BASE_C_FLAGS
-        -g3      # Maximum debug information
-        -O0      # Disable optimization for easier debugging
-        -DDEBUG=1 -DBCPL_DEBUG=1
-    )
-elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-    list(APPEND BCPL_BASE_C_FLAGS
-        -g       # Minimal debug information
-        -O2      # Balanced optimization level
-        -DNDEBUG=1
+        $<$<CONFIG:Debug>:-g3;-O0;-DDEBUG=1;-DBCPL_DEBUG=1>
+        $<$<CONFIG:RelWithDebInfo>:-g;-O2;-DNDEBUG=1>
+        $<$<CONFIG:Release>:-O2;-DNDEBUG=1>
     )
 else()
-    list(APPEND BCPL_BASE_C_FLAGS
-        -O2      # Default optimization level for production
-        -DNDEBUG=1
-    )
+    if(_BCPL_BUILD_TYPE STREQUAL "DEBUG")
+        list(APPEND BCPL_BASE_C_FLAGS
+            -g3      # Maximum debug information
+            -O0      # Disable optimization for easier debugging
+            -DDEBUG=1 -DBCPL_DEBUG=1
+        )
+    elseif(_BCPL_BUILD_TYPE STREQUAL "RELWITHDEBINFO")
+        list(APPEND BCPL_BASE_C_FLAGS
+            -g       # Minimal debug information
+            -O2      # Balanced optimization level
+            -DNDEBUG=1
+        )
+    else()
+        list(APPEND BCPL_BASE_C_FLAGS
+            -O2      # Default optimization level for production
+            -DNDEBUG=1
+        )
+    endif()
 endif()
 
 # -----------------------------------------------------------------------------

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.20)
+
+# Documentation build configuration
+
+if(NOT ENABLE_DOCS)
+    message(STATUS "Documentation generation disabled")
+    return()
+endif()
+
+find_package(Doxygen REQUIRED)
+find_package(Sphinx REQUIRED)
+
+# Doxygen configuration
+set(DOXYGEN_IN ${CMAKE_SOURCE_DIR}/Doxyfile)
+set(DOXYGEN_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/doxygen)
+
+add_custom_target(doc_doxygen
+    COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_IN}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Generating API documentation with Doxygen"
+)
+
+# Sphinx configuration
+set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/sphinx)
+set(SPHINX_BUILD  ${CMAKE_CURRENT_BINARY_DIR}/sphinx)
+
+add_custom_target(doc_sphinx
+    COMMAND ${SPHINX_EXECUTABLE} -b html ${SPHINX_SOURCE} ${SPHINX_BUILD}/html
+    DEPENDS doc_doxygen
+    COMMENT "Generating developer documentation with Sphinx"
+)
+
+add_custom_target(doc ALL DEPENDS doc_doxygen doc_sphinx)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -185,15 +185,24 @@ add_custom_target(st_gen_${TARGET_ARCH} ALL
 find_package(LLVM QUIET CONFIG)
 if(LLVM_FOUND)
     message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION} - enabling LLVM backend")
-    
+
     include_directories(${LLVM_INCLUDE_DIRS})
     separate_arguments(LLVM_DEFINITIONS_LIST UNIX_COMMAND "${LLVM_DEFINITIONS}")
     add_definitions(${LLVM_DEFINITIONS_LIST})
-    
+
     llvm_map_components_to_libnames(LLCG_LIBS
         core bitwriter native analysis target
     )
-    
+
+    # Enable C++ support only when building the LLVM backend
+    enable_language(CXX)
+    set(BCPL_CXX_FLAGS
+        ${BCPL_BASE_C_FLAGS}
+        -std=c++17
+        -Woverloaded-virtual
+        -Wnon-virtual-dtor
+    )
+
     add_executable(llcg llcg.cpp)
     target_compile_options(llcg PRIVATE ${BCPL_CXX_FLAGS})
     target_link_libraries(llcg PRIVATE ${LLCG_LIBS} bcpl_runtime)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.20)
+
+# Testing configuration for BCPL Compiler
+
+# Collect all test sources
+set(TEST_SOURCES
+    test_runtime.c
+    test_platform_abstraction.c
+    test_memory_safety.c
+    test_architecture.c
+    test_cross_platform.c
+    test_performance.c
+    test_assembly_elimination.c
+)
+
+add_executable(bcpl_tests ${TEST_SOURCES})
+
+# Tests depend on the runtime library built in src/
+# Include directories to access internal headers
+
+target_include_directories(bcpl_tests PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/include
+    ${CMAKE_SOURCE_DIR}/src/runtime
+)
+
+target_link_libraries(bcpl_tests PRIVATE bcpl_runtime)
+
+target_compile_definitions(bcpl_tests PRIVATE BCPL_TEST_BUILD=1)
+target_compile_options(bcpl_tests PRIVATE
+    ${BCPL_BASE_C_FLAGS}
+    ${BCPL_ARCH_FLAGS}
+    -DBITS=${BCPL_ARCH_BITS}
+    -DBCPL_PLATFORM_${BCPL_PLATFORM}=1
+    -DTARGET_ARCH_${TARGET_ARCH}=1
+)
+
+# Apply optional tooling flags
+apply_tooling_flags(bcpl_tests)
+
+# Register with CTest
+add_test(NAME bcpl_tests COMMAND bcpl_tests)


### PR DESCRIPTION
## Summary
- add `ENABLE_TESTS` option in root CMake
- provide new `docs/CMakeLists.txt` to build Doxygen and Sphinx docs
- provide new `tests/CMakeLists.txt` building bcpl test suite
- enable C++ for optional LLVM backend in `src/CMakeLists.txt`

## Testing
- `cmake -S . -B build_tmp` *(passed)*
- `cmake --build build_tmp --target bcpl_runtime`

------
https://chatgpt.com/codex/tasks/task_e_688a3d99ab888331a82e53f0ef33b9a5

## Summary by Sourcery

Enhance the CMake build system by adding optional test and documentation targets, improving build-type handling, and enabling a C++ LLVM backend

New Features:
- Add ENABLE_TESTS option and tests/CMakeLists.txt to build the BCPL test suite with CTest
- Add docs/CMakeLists.txt to generate Doxygen and Sphinx documentation
- Enable C++ support and C++17 flags when configuring the LLVM backend in src/CMakeLists.txt

Enhancements:
- Normalize default build type to Release and add multi-config support in CompilerFlags.cmake using generator expressions