### PR TITLE
Fix dynamic path detection in scripts

### DIFF
--- a/scripts/consolidate.sh
+++ b/scripts/consolidate.sh
@@ -5,7 +5,11 @@
 
 set -e
 
-PROJECT_ROOT="/Users/eirikr/Documents/GitHub/bcpl-compiler"
+# Determine the repository root dynamically so the script can be
+# executed from any working directory.  `git rev-parse --show-toplevel`
+# prints the absolute path to the top-level directory of the current
+# Git repository.
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
 cd "$PROJECT_ROOT"
 
 echo "=== BCPL Compiler Project Final Consolidation ==="

--- a/scripts/reorganize.sh
+++ b/scripts/reorganize.sh
@@ -5,7 +5,10 @@
 set -e  # Exit on any error
 
 ARCHIVE_DIR="archive"
-PROJECT_ROOT="/Users/eirikr/Documents/GitHub/bcpl-compiler"
+# Determine the repository root dynamically.  This allows the
+# reorganization script to be invoked from any location in or
+# outside the repository.
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
 
 echo "=== BCPL Compiler Project Reorganization ==="
 echo "Starting reorganization at: $(date)"


### PR DESCRIPTION
## Summary
- compute project root using `git rev-parse --show-toplevel`
- keep scripts functional from any working directory

## Testing
- `scripts/test_bcpl.sh`
- `bash -n /workspace/bcpl-compiler/scripts/consolidate.sh`
- `bash -n /workspace/bcpl-compiler/scripts/reorganize.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a40023aa48331b145ca8c14e7d0bf