### PR TITLE
Fix absolute PROJECT_ROOT path

### DIFF
--- a/archive/legacy_files/HARMONIZATION_REPORT.md
+++ b/archive/legacy_files/HARMONIZATION_REPORT.md
@@ -29,7 +29,7 @@
 ## Final Structure
 
 ```
-/Users/eirikr/Documents/GitHub/bcpl-compiler
+<PROJECT_ROOT>
 ├── CHANGES
 ├── CMakeLists.txt
 ├── CMakePresets.json

--- a/archive/legacy_files/consolidate.sh
+++ b/archive/legacy_files/consolidate.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-PROJECT_ROOT="/Users/eirikr/Documents/GitHub/bcpl-compiler"
+PROJECT_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
 cd "$PROJECT_ROOT"
 
 echo "=== BCPL Compiler Project Final Consolidation ==="

--- a/archive/legacy_files/reorganize.sh
+++ b/archive/legacy_files/reorganize.sh
@@ -5,7 +5,7 @@
 set -e  # Exit on any error
 
 ARCHIVE_DIR="archive"
-PROJECT_ROOT="/Users/eirikr/Documents/GitHub/bcpl-compiler"
+PROJECT_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
 
 echo "=== BCPL Compiler Project Reorganization ==="
 echo "Starting reorganization at: $(date)"

--- a/scripts/consolidate.sh
+++ b/scripts/consolidate.sh
@@ -5,7 +5,7 @@
 
 set -e
 
-PROJECT_ROOT="/Users/eirikr/Documents/GitHub/bcpl-compiler"
+PROJECT_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
 cd "$PROJECT_ROOT"
 
 echo "=== BCPL Compiler Project Final Consolidation ==="

--- a/scripts/reorganize.sh
+++ b/scripts/reorganize.sh
@@ -5,7 +5,7 @@
 set -e  # Exit on any error
 
 ARCHIVE_DIR="archive"
-PROJECT_ROOT="/Users/eirikr/Documents/GitHub/bcpl-compiler"
+PROJECT_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
 
 echo "=== BCPL Compiler Project Reorganization ==="
 echo "Starting reorganization at: $(date)"


### PR DESCRIPTION
## Summary
- dynamically detect PROJECT_ROOT in reorganize and consolidate scripts
- update legacy copies of these scripts
- clarify project root placeholder in harmonization doc

## Testing
- `./scripts/validate_modernization.sh` *(fails: Universal compiler compatibility)*

------
https://chatgpt.com/codex/tasks/task_e_688a40065f308331913bdf81e07c037a