### PR TITLE
Refine build script and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cd bcpl-compiler
 
 # Test with a simple program
 echo 'GET "LIBHDR"; LET START() BE WRITES("Hello, BCPL!")' > hello.bcpl
-./build/Release/src/bcplc hello.bcpl
+./build/Release-native/src/bcplc hello.bcpl
 ./hello
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,41 @@
 #!/bin/bash
-# build.sh - Wrapper script for invoking CMake builds
-# Usage: ./build.sh [BuildType]
-# Defaults to "Release" when no argument is provided.
-# The build artifacts are placed under build/<BuildType>.
-set -e
-BUILD_TYPE="${1:-Release}"
-BUILD_DIR="build/${BUILD_TYPE}"
+#!/bin/bash
+# build.sh - Unified BCPL compiler build helper
+# Usage: ./build.sh [BuildType] [Architecture]
+# BuildType    : Release, Debug, RelWithDebInfo, MinSizeRel
+# Architecture : native (default), x86_64, arm64, x86_32, arm32, x86_16
+# Build artifacts are placed under build/<BuildType>-<Architecture>
 
-# Configure with the chosen build type
-cmake -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" .
+set -euo pipefail
+
+BUILD_TYPE="${1:-Release}"
+ARCHITECTURE="${2:-native}"
+
+# Validate architecture argument
+SUPPORTED_ARCHS=(native x86_64 arm64 x86_32 arm32 x86_16)
+if [[ ! " ${SUPPORTED_ARCHS[*]} " =~ " ${ARCHITECTURE} " ]]; then
+    echo "Error: unsupported architecture '${ARCHITECTURE}'." >&2
+    echo "Supported architectures: ${SUPPORTED_ARCHS[*]}" >&2
+    exit 1
+fi
+
+# Resolve 'native' architecture to host
+if [[ "${ARCHITECTURE}" == "native" ]]; then
+    case "$(uname -m)" in
+        x86_64|amd64) ARCHITECTURE="x86_64" ;;
+        aarch64|arm64) ARCHITECTURE="arm64" ;;
+        i?86) ARCHITECTURE="x86_32" ;;
+        arm*) ARCHITECTURE="arm32" ;;
+    esac
+fi
+
+BUILD_DIR="build/${BUILD_TYPE}-${ARCHITECTURE}"
+
+cmake -B "$BUILD_DIR" \
+      -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+      -DBCPL_TARGET_ARCH="${ARCHITECTURE}" \
+      .
 
 # Build using all available cores
-cmake --build "$BUILD_DIR" --parallel "$(nproc 2>/dev/null || sysctl -n hw.ncpu)"
+cmake --build "$BUILD_DIR" --parallel "$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -159,13 +159,13 @@ build/
 ```bash
 # Test the compiler with a simple program
 echo 'GET "LIBHDR"; LET START() BE WRITES("Hello, BCPL!")' > test.bcpl
-./build/Release/src/bcplc test.bcpl
+./build/Release-native/src/bcplc test.bcpl
 ./test
 ```
 
 ### Run Test Suite
 ```bash
-cd build/Release
+cd build/Release-native
 ctest                          # Run all tests
 ctest -R unit                  # Run unit tests only
 ctest -R integration           # Run integration tests only
@@ -297,7 +297,7 @@ jobs:
     - name: Build
       run: ./build.sh Release ${{ matrix.arch }}
     - name: Test
-      run: cd build/Release && ctest
+      run: cd build/Release-${{ matrix.arch }} && ctest
 ```
 
 ## Custom Builds

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,89 +33,31 @@ include(Options)
 # MODERNIZATION VALIDATION TESTS
 # ============================================================================
 
-# Test 1: Runtime modernization validation
-add_executable(test_runtime_modernization
+set(TEST_SOURCES
     test_runtime.c
     test_platform_abstraction.c
     test_memory_safety.c
-)
-
-target_include_directories(test_runtime_modernization PRIVATE
-    ${CMAKE_SOURCE_DIR}/src/include
-    ${CMAKE_SOURCE_DIR}/src/runtime
-)
-
-target_link_libraries(test_runtime_modernization PRIVATE
-    bcpl_runtime
-)
-
-target_compile_definitions(test_runtime_modernization PRIVATE
-    BCPL_TEST_BUILD=1
-    BCPL_MODERNIZED=1
-)
-
-# Test 2: Cross-platform compatibility
-add_executable(test_platform_compatibility
     test_cross_platform.c
     test_architecture.c
-)
-
-target_include_directories(test_platform_compatibility PRIVATE
-    ${CMAKE_SOURCE_DIR}/src/include
-)
-
-target_link_libraries(test_platform_compatibility PRIVATE
-    bcpl_runtime
-)
-
-# Test 3: Performance validation
-add_executable(test_performance
     test_performance.c
-)
-
-target_include_directories(test_performance PRIVATE
-    ${CMAKE_SOURCE_DIR}/src/include
-)
-
-target_link_libraries(test_performance PRIVATE
-    bcpl_runtime
-)
-
-# Test 4: Assembly elimination validation
-add_executable(test_no_assembly
     test_assembly_elimination.c
 )
 
-target_include_directories(test_no_assembly PRIVATE
-    ${CMAKE_SOURCE_DIR}/src/include
-)
-
-target_link_libraries(test_no_assembly PRIVATE
-    bcpl_runtime
-)
-
-# Apply tooling flags to each test executable
-apply_tooling_flags(test_runtime_modernization)
-apply_tooling_flags(test_platform_compatibility)
-apply_tooling_flags(test_performance)
-apply_tooling_flags(test_no_assembly)
-
-# ============================================================================
-# TEST EXECUTION
-# ============================================================================
-
-# Register all tests with CTest
-add_test(NAME runtime_modernization 
-         COMMAND test_runtime_modernization)
-
-add_test(NAME platform_compatibility 
-         COMMAND test_platform_compatibility)
-
-add_test(NAME performance_validation 
-         COMMAND test_performance)
-
-add_test(NAME assembly_elimination 
-         COMMAND test_no_assembly)
+foreach(src ${TEST_SOURCES})
+    get_filename_component(test_name ${src} NAME_WE)
+    add_executable(${test_name} ${src})
+    target_include_directories(${test_name} PRIVATE
+        ${CMAKE_SOURCE_DIR}/src/include
+        ${CMAKE_SOURCE_DIR}/src/runtime
+    )
+    target_compile_definitions(${test_name} PRIVATE
+        BCPL_TEST_BUILD=1
+        BCPL_MODERNIZED=1
+    )
+    target_link_libraries(${test_name} PRIVATE bcpl_runtime)
+    apply_tooling_flags(${test_name})
+    add_test(NAME ${test_name} COMMAND ${test_name})
+endforeach()
 
 # ============================================================================
 # INTEGRATION TESTS

--- a/tests/test_assembly_elimination.c
+++ b/tests/test_assembly_elimination.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 // Include our modernized headers
 #ifdef BCPL_MODERNIZED

--- a/tests/test_performance.c
+++ b/tests/test_performance.c
@@ -5,6 +5,7 @@
  * @date 2025
  */
 
+#define _POSIX_C_SOURCE 200809L
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/test_platform_abstraction.c
+++ b/tests/test_platform_abstraction.c
@@ -88,40 +88,43 @@ static int test_universal_file_operations(void) {
       "BCPL Modernization Test Data - Universal Platform Support";
 
   // Test file creation and writing
-  FILE *file = bcpl_platform_fopen(test_filename, "w");
+  bcpl_file_handle_t *file =
+      bcpl_platform_fopen(test_filename, 'w', false);
   if (!file) {
     printf("❌ Failed to create test file\n");
     return 0;
   }
 
-  size_t written = fwrite(test_data, 1, strlen(test_data), file);
+  size_t written = fwrite(test_data, 1, strlen(test_data),
+                          file->native_handle);
   if (written != strlen(test_data)) {
     printf("❌ Failed to write complete test data\n");
-    fclose(file);
+    bcpl_platform_fclose(file);
     return 0;
   }
 
-  fclose(file);
+  bcpl_platform_fclose(file);
   printf("✅ File creation and writing successful\n");
 
   // Test file reading
-  file = bcpl_platform_fopen(test_filename, "r");
+  file = bcpl_platform_fopen(test_filename, 'r', false);
   if (!file) {
     printf("❌ Failed to open test file for reading\n");
     return 0;
   }
 
   char read_buffer[256];
-  size_t read_bytes = fread(read_buffer, 1, sizeof(read_buffer) - 1, file);
+  size_t read_bytes = fread(read_buffer, 1, sizeof(read_buffer) - 1,
+                            file->native_handle);
   read_buffer[read_bytes] = '\0';
 
   if (strcmp(read_buffer, test_data) != 0) {
     printf("❌ Read data doesn't match written data\n");
-    fclose(file);
+    bcpl_platform_fclose(file);
     return 0;
   }
 
-  fclose(file);
+  bcpl_platform_fclose(file);
   printf("✅ File reading and data integrity verified\n");
 
   // Clean up
@@ -208,9 +211,9 @@ static int test_architecture_optimizations(void) {
     ((char *)src)[i] = (char)(i & 0xFF);
   }
 
-  // Test optimized copy
+  // Test memory copy via platform abstraction
   uint64_t start = bcpl_platform_get_time_ns();
-  bcpl_platform_memcpy_optimized(dst, src, test_size);
+  bcpl_platform_memcpy(dst, src, test_size);
   uint64_t end = bcpl_platform_get_time_ns();
 
   // Verify copy


### PR DESCRIPTION
## Summary
- add architecture support and validation to `build.sh`
- update docs for new build directory naming
- simplify test suite build logic
- fix platform abstraction and performance tests

## Testing
- `cmake -B build/Release -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTS=ON .`
- `cmake --build build/Release --parallel $(nproc)`
- `cd build/Release-x86_64 && ctest --output-on-failure` *(fails: 3 tests)*

------
https://chatgpt.com/codex/tasks/task_e_688a4a4fe5348331a9bd60f56ebbd237