### PR TITLE
Fix tool ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,10 @@ tools/*.o
 src/st
 src/cg
 src/op
-tools/*
-!tools/CMakeLists.txt
+# Ignore generated binaries in tools/
+tools/cmpltest
+tools/xref
+tools/gpm
 build/
 
 # Misc temporary files

--- a/docs/REPOSITORY_HYGIENE.md
+++ b/docs/REPOSITORY_HYGIENE.md
@@ -1,0 +1,11 @@
+# Repository Hygiene
+
+This document captures conventions for keeping the repository free from unwanted
+build artifacts while retaining source files that describe tooling. Binaries
+produced during the build of BCPL tools can clutter history and lead to
+unnecessary conflicts. They are generated deterministically from the `bcplc`
+compiler and therefore do not need to be tracked.
+
+The `.gitignore` file now ignores only the compiled executables in `tools/`
+(`cmpltest`, `xref` and `gpm`) and their object files. The sources and
+`Makefile` remain version-controlled so that the build remains reproducible.


### PR DESCRIPTION
## Summary
- fine-tune ignored files in `tools/`
- document repository hygiene for generated tools

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688abbd44fa08331a42e8a25291f98d1