### PR TITLE
Remove duplicate error declaration

### DIFF
--- a/src/cg_modern.h
+++ b/src/cg_modern.h
@@ -424,13 +424,6 @@ void force(int stack_level);
 void loadreg(int reg, int condition);
 
 /**
- * @brief Report error and exit
- * @param format Printf-style format string
- * @param ... Arguments for format string
- */
-void error(const char *format, ...);
-
-/**
  * @brief Read operation from OCODE stream
  * @param dummy Unused parameter for compatibility
  * @return Operation code


### PR DESCRIPTION
## Summary
- deduplicate `error()` declaration in `cg_modern.h`

## Testing
- `cmake --preset default`
- `cmake --build --preset default`
- `cd build/default && ctest --output-on-failure` *(fails: missing `bcplc` executable)*

------
https://chatgpt.com/codex/tasks/task_e_688abbe31bb483318fc980bfbb5b64bb

## Summary by Sourcery

Enhancements:
- Remove duplicate error() declaration in cg_modern.h