### PR TITLE
Fix zero-size vector allocation and add test

### DIFF
--- a/src/platform/linux.c
+++ b/src/platform/linux.c
@@ -228,6 +228,9 @@ uint64_t bcpl_nano_time(void) {
 // =============================================================================
 
 void *bcpl_platform_aligned_alloc(size_t size, size_t alignment) {
+  if (size == 0)
+    return NULL;
+
   void *ptr = NULL;
   if (posix_memalign(&ptr, alignment, size) == 0)
     return ptr;

--- a/src/platform/macos.c
+++ b/src/platform/macos.c
@@ -452,6 +452,9 @@ void bcpl_platform_sleep_ms(uint32_t milliseconds) {
  * @return Aligned memory pointer or NULL
  */
 void *bcpl_platform_aligned_alloc(size_t size, size_t alignment) {
+  if (size == 0)
+    return NULL;
+
   // Use posix_memalign for aligned allocation
   void *ptr = NULL;
   if (posix_memalign(&ptr, alignment, size) == 0) {

--- a/src/runtime/memory.c
+++ b/src/runtime/memory.c
@@ -13,7 +13,7 @@
  * @brief Allocate a BCPL vector
  */
 bcpl_vector_t *bcpl_getvec(bcpl_word_t size) {
-  if (size <= 0) {
+  if (size == 0) {
     return NULL;
   }
 

--- a/tests/test_runtime.c
+++ b/tests/test_runtime.c
@@ -29,6 +29,7 @@
 
 // Include modernized runtime headers
 #include "universal_platform.h"
+#include "bcpl_runtime.h"
 
 // ============================================================================
 // TEST FRAMEWORK INFRASTRUCTURE
@@ -124,6 +125,10 @@ void test_memory_management(void) {
   // Test zero-size allocation (should handle gracefully)
   void *ptr3 = bcpl_platform_aligned_alloc(0, BCPL_MEMORY_ALIGNMENT);
   TEST_ASSERT(ptr3 == NULL, "Zero-size allocation handling");
+
+  // Test bcpl_getvec with zero size returns NULL
+  bcpl_vector_t *vec_zero = bcpl_getvec(0);
+  TEST_ASSERT(vec_zero == NULL, "bcpl_getvec zero-size handling");
 
   // Test cleanup
   bcpl_platform_aligned_free(ptr1);


### PR DESCRIPTION
## Summary
- correct `bcpl_getvec` to treat only zero as invalid
- make aligned alloc return NULL when size is zero
- check for zero-size behaviour in runtime tests
- ensure tests include runtime headers

## Testing
- `./build.sh`
- `ctest --output-on-failure` *(fails: bcpl_compilation)*

------
https://chatgpt.com/codex/tasks/task_e_688abbd0a2348331bdea0ad351118529