### PR TITLE
Fix analysis doc paths

### DIFF
--- a/docs/REPOSITORY_ANALYSIS.md
+++ b/docs/REPOSITORY_ANALYSIS.md
@@ -67,8 +67,21 @@ Total nloc   Avg.NLOC  AvgCCN  Avg.token   Fun Cnt  Warning cnt   Fun Rt   nloc 
 ------------------------------------------------------------------------------------------
       7930      10.8     3.2       62.3      561            6      0.01    0.06
 
-The complete report is available in `/tmp/lizard_report.txt`.
+The complete report is available in `docs/analysis/lizard_report.txt`.
 
 ## Checksum Manifest
 
-A SHA-256 checksum manifest of all files was generated and saved to `/tmp/sha256sums.txt`.
+A SHA-256 checksum manifest of all files was generated and saved to `docs/analysis/sha256sums.txt`.
+
+Both files are tracked in the repository for convenience. If they are missing or
+out of date, regenerate them from the repository root:
+
+```bash
+mkdir -p docs/analysis
+cloc --json . > docs/analysis/cloc.json
+lizard -Ecpp src > docs/analysis/lizard_report.txt
+sha256sum $(git ls-files) > docs/analysis/sha256sums.txt
+```
+
+Storing reports under `docs/analysis/` keeps the tree tidy and avoids absolute
+paths that can become stale across machines.


### PR DESCRIPTION
## Summary
- store analysis reports under `docs/analysis`
- mention commands to regenerate reports

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688abbc0b0708331a01caae807694228