### PR TITLE
Fix setup script path in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ensure the following tools are installed:
 - `make` or `ninja`
 - `binutils`, `gcc-multilib`, and `qemu` for cross builds
 
-Running `./setup.sh` installs all dependencies along with an IA‑16 toolchain.
+Running `scripts/setup.sh` installs all dependencies along with an IA‑16 toolchain.
 
 For convenience, a `build.sh` helper script wraps the standard CMake
 configuration and build commands. It places artifacts under

--- a/docs/build_steps.md
+++ b/docs/build_steps.md
@@ -7,7 +7,7 @@ all required packages (compilers, emulators, analysis tools such as `valgrind`,
 
 1. **Run the setup script**
    ```sh
-   sudo ./setup.sh
+   sudo ./scripts/setup.sh
    ```
    The script enables additional package repositories, installs a wide array of
    developer tools and instrumentations, then configures multi‑architecture

--- a/docs/doxygen/html/_r_e_a_d_m_e_source.html
+++ b/docs/doxygen/html/_r_e_a_d_m_e_source.html
@@ -119,14 +119,14 @@ $(function() {
 <div class="line"><a id="l00042" name="l00042"></a><span class="lineno">   42</span>    gcc-multilib</div>
 <div class="line"><a id="l00043" name="l00043"></a><span class="lineno">   43</span>    qemu</div>
 <div class="line"><a id="l00044" name="l00044"></a><span class="lineno">   44</span> </div>
-<div class="line"><a id="l00045" name="l00045"></a><span class="lineno">   45</span>Running ``./setup.sh`` installs all of the above along with a full</div>
+<div class="line"><a id="l00045" name="l00045"></a><span class="lineno">   45</span>Running ``scripts/setup.sh`` installs all of the above along with a full</div>
 <div class="line"><a id="l00046" name="l00046"></a><span class="lineno">   46</span>cross‑compilation environment and the IA‑16 toolchain.</div>
 <div class="line"><a id="l00047" name="l00047"></a><span class="lineno">   47</span> </div>
 <div class="line"><a id="l00048" name="l00048"></a><span class="lineno">   48</span>Building</div>
 <div class="line"><a id="l00049" name="l00049"></a><span class="lineno">   49</span>========</div>
 <div class="line"><a id="l00050" name="l00050"></a><span class="lineno">   50</span> </div>
 <div class="line"><a id="l00051" name="l00051"></a><span class="lineno">   51</span>Before building you may install a comprehensive cross‑compilation</div>
-<div class="line"><a id="l00052" name="l00052"></a><span class="lineno">   52</span>environment by running ``./setup.sh`` as root.  The script configures</div>
+<div class="line"><a id="l00052" name="l00052"></a><span class="lineno">   52</span>environment by running ``scripts/setup.sh`` as root.  The script configures</div>
 <div class="line"><a id="l00053" name="l00053"></a><span class="lineno">   53</span>package repositories for multiple architectures and installs toolchains</div>
 <div class="line"><a id="l00054" name="l00054"></a><span class="lineno">   54</span>and emulators such as ``qemu`` to enable execution of foreign binaries,</div>
 <div class="line"><a id="l00055" name="l00055"></a><span class="lineno">   55</span>including 16‑bit and 32‑bit x86 programs.  This is optional for a</div>

--- a/docs/doxygen/xml/_r_e_a_d_m_e.xml
+++ b/docs/doxygen/xml/_r_e_a_d_m_e.xml
@@ -51,14 +51,14 @@
 <codeline><highlight class="normal"><sp/><sp/><sp/><sp/>gcc-multilib</highlight></codeline>
 <codeline><highlight class="normal"><sp/><sp/><sp/><sp/>qemu</highlight></codeline>
 <codeline></codeline>
-<codeline><highlight class="normal">Running<sp/>``./setup.sh``<sp/>installs<sp/>all<sp/>of<sp/>the<sp/>above<sp/>along<sp/>with<sp/>a<sp/>full</highlight></codeline>
+<codeline><highlight class="normal">Running<sp/>``scripts/setup.sh``<sp/>installs<sp/>all<sp/>of<sp/>the<sp/>above<sp/>along<sp/>with<sp/>a<sp/>full</highlight></codeline>
 <codeline><highlight class="normal">cross‑compilation<sp/>environment<sp/>and<sp/>the<sp/>IA‑16<sp/>toolchain.</highlight></codeline>
 <codeline></codeline>
 <codeline><highlight class="normal">Building</highlight></codeline>
 <codeline><highlight class="normal">========</highlight></codeline>
 <codeline></codeline>
 <codeline><highlight class="normal">Before<sp/>building<sp/>you<sp/>may<sp/>install<sp/>a<sp/>comprehensive<sp/>cross‑compilation</highlight></codeline>
-<codeline><highlight class="normal">environment<sp/>by<sp/>running<sp/>``./setup.sh``<sp/>as<sp/>root.<sp/><sp/>The<sp/>script<sp/>configures</highlight></codeline>
+<codeline><highlight class="normal">environment<sp/>by<sp/>running<sp/>``scripts/setup.sh``<sp/>as<sp/>root.<sp/><sp/>The<sp/>script<sp/>configures</highlight></codeline>
 <codeline><highlight class="normal">package<sp/>repositories<sp/>for<sp/>multiple<sp/>architectures<sp/>and<sp/>installs<sp/>toolchains</highlight></codeline>
 <codeline><highlight class="normal">and<sp/>emulators<sp/>such<sp/>as<sp/>``qemu``<sp/>to<sp/>enable<sp/>execution<sp/>of<sp/>foreign<sp/>binaries,</highlight></codeline>
 <codeline><highlight class="normal">including<sp/>16‑bit<sp/>and<sp/>32‑bit<sp/>x86<sp/>programs.<sp/><sp/>This<sp/>is<sp/>optional<sp/>for<sp/>a</highlight></codeline>

--- a/docs/sphinx/tools-utilities.rst
+++ b/docs/sphinx/tools-utilities.rst
@@ -231,11 +231,11 @@ Usage Examples
 **Development Workflow**
    .. code-block:: bash
    
-      # Set up development environment
-      ./setup.sh
+       # Set up development environment
+       ./scripts/setup.sh
       
-      # Build everything
-      ./makeall.sh
+       # Build everything
+       ./scripts/makeall.sh
       
       # Run tests
       bcpl cmpltest.bcpl


### PR DESCRIPTION
## Summary
- reference scripts/setup.sh in README and docs
- update Sphinx and Doxygen sources

## Testing
- `scripts/check_status.sh > /tmp/check_status.log`


------
https://chatgpt.com/codex/tasks/task_e_688abbed78a483318b08c2deafafa704