### PR TITLE
Guard zero-length allocations in bcpl runtime

### DIFF
--- a/src/runtime/memory.c
+++ b/src/runtime/memory.c
@@ -14,6 +14,8 @@
  */
 bcpl_vector_t *bcpl_getvec(bcpl_word_t size) {
   if (size == 0) {
+    // Zero-length allocations are unsupported by the BCPL runtime.
+    // Returning NULL communicates allocation failure to callers.
     return NULL;
   }
 

--- a/tests/test_memory.c
+++ b/tests/test_memory.c
@@ -28,11 +28,19 @@ static int test_reference_counting(void) {
     return 0;
 }
 
+static int test_zero_allocation(void) {
+    bcpl_vector_t *vec = bcpl_getvec(0);
+    TEST_ASSERT(vec == NULL, "Zero-sized allocation returns NULL");
+    return 0;
+}
+
 int run_test_memory(void) {
     printf("Memory Management Tests\n");
     printf("======================\n");
 
-    int result = test_reference_counting();
+    int result = 0;
+    result |= test_reference_counting();
+    result |= test_zero_allocation();
     if (result == 0) {
         printf("All memory tests PASSED\n");
     } else {


### PR DESCRIPTION
## Summary
- document and guard against zero-sized `bcpl_getvec` allocations
- add a memory unit test ensuring zero-sized requests return `NULL`

## Testing
- `./build.sh Debug`
- `ctest --test-dir build/Debug -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68aa5ae4b3248331912f920e3dadb608