### PR TITLE
Refine tools gitignore and document policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ src/blib.s
 src/st
 src/cg
 src/op
-!tools/CMakeLists.txt
 /builds/
 docs/doxygen/
 docs/sphinx/_build/
@@ -39,14 +38,14 @@ docs/sphinx/_build/
 # Executable outputs
 *.exe
 */bcplc
-# tools/* # Commented out to avoid ignoring essential tool source files if any; specific executables should be listed
-!tools/CMakeLists.txt # Keep this
-# build/ # This is too general if there are legitimate 'build' named source dirs. Specific build output dirs are better.
-# Ignore generated binaries in tools/
-tools/cmpltest
-tools/xref
-tools/gpm
-build/
+
+# Tools: track source files but ignore compiled binaries
+/tools/*
+!/tools/*.bcpl
+!/tools/Makefile*
+!/tools/CMakeLists.txt
+
+/build/
 
 # IDE and temporary files
 .DS_Store
@@ -58,9 +57,6 @@ compile_commands.json
 /src/st
 /src/cg
 /src/op
-/tools/cmpltest
-/tools/xref
-/tools/gpm
 .DS_Store
 
 # CMake build files and directories

--- a/REPOSITORY_HYGIENE.md
+++ b/REPOSITORY_HYGIENE.md
@@ -11,6 +11,7 @@ The repository was cluttered with build artifacts, generated documentation, and 
 -   **.gitignore updated:** The `.gitignore` file was updated with a comprehensive set of rules to ignore build outputs, generated documentation, and other temporary files.
 -   **Binaries removed:** Standalone binary executables were removed from the repository.
 -   **Build artifacts removed:** Some build artifacts (`*.a`, `compile_commands.json`) were removed.
+-   **Tool binaries ignored selectively:** The `tools/` directory now ignores only compiler-generated executables while keeping source `.bcpl` files and makefiles under version control. This ensures that essential tool sources remain transparent and reproducible without polluting the repository with build products.
 
 ### Limitations
 


### PR DESCRIPTION
## Summary
- Ignore only generated binaries in `tools/` while keeping source and build files versioned
- Document selective ignore policy in repository hygiene guidelines

## Testing
- `ctest --output-on-failure` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5ae778d48331b06608e20d126057