### PR TITLE
docs: clarify analysis report storage

### DIFF
--- a/docs/REPOSITORY_ANALYSIS.md
+++ b/docs/REPOSITORY_ANALYSIS.md
@@ -2,8 +2,15 @@
 
 This document summarizes automated analysis results for the BCPL compiler repository.
 
+All of the raw reports that underpin this summary are stored within the
+repository under `docs/analysis/`. Keeping artifacts in a project-relative
+directory makes the results reproducible and avoids references to machine
+specific temporary locations.
+
 
 ## File Statistics
+
+The following language statistics were extracted from `docs/analysis/cloc.json`:
 
 {"header" : {
   "cloc_url"           : "github.com/AlDanial/cloc",


### PR DESCRIPTION
## Summary
- document that analysis artifacts live under `docs/analysis/`
- guide contributors on regenerating reports without using machine-specific temp paths

## Testing
- `ctest --test-dir build_Release`

------
https://chatgpt.com/codex/tasks/task_e_68aa5ada36a48331a2e15a4b3ffd9417