### PR TITLE
Remove redundant error declaration in cg_modern.h

### DIFF
--- a/src/cg_modern.h
+++ b/src/cg_modern.h
@@ -500,7 +500,6 @@ static const int xitab[] = {0x03, 0x03, 0x01, 0x01, 0x02, 0x02, 0x02,
 
 // Forward declarations for legacy functions
 extern void emit(const char *format, ...);
-extern void error(const char *format, ...);
 extern int rdn(void);
 extern void codelab(int label);
 extern const char *label(int n);


### PR DESCRIPTION
## Summary
- Remove duplicate `error` function declaration from `cg_modern.h`

## Testing
- `cmake --build --preset default`
- `cd build/default && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68aa5af0583883318382c4787b5de6bb