### PR TITLE
Export Windows platform init

### DIFF
--- a/src/platform/windows.c
+++ b/src/platform/windows.c
@@ -97,7 +97,7 @@ const char *bcpl_get_env(const char *name) {
  * always indicates success with a zero result to align with the other
  * platform implementations.
  */
-int bcpl_platform_init(void) {
+BCPL_EXPORT int bcpl_platform_init(void) {
   /* Set console to UTF-8 if available.  This allows UTF-8 encoded
      text to be displayed correctly on supported terminals. */
   SetConsoleOutputCP(CP_UTF8);


### PR DESCRIPTION
## Summary
- Export `bcpl_platform_init` on Windows to match header declaration and return status code

## Testing
- `./build.sh`
- `cd build/Release && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68aa5af1257483318d43b5999113f8da