### PR TITLE
docs: clarify setup script path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This repository contains a modernized distribution of the classic **BCPL** compi
 git clone https://github.com/eirikr/bcpl-compiler.git
 cd bcpl-compiler
 
+# Install dependencies
+./scripts/setup.sh
+
 # Build the compiler (native release)
 ./build.sh
 
@@ -50,7 +53,7 @@ Ensure the following tools are installed:
 - Python 3 with `pip`; install dependencies with
   `pip install -r requirements.txt`
 
-Running `scripts/setup.sh` installs all dependencies along with an IA‑16 toolchain.
+Running `./scripts/setup.sh` installs all dependencies along with an IA‑16 toolchain.
 
 For convenience, a `build.sh` helper script wraps the standard CMake
 configuration and build commands. It places artifacts under

--- a/archive/legacy_files/README
+++ b/archive/legacy_files/README
@@ -42,7 +42,7 @@ least the following packages are available::
     gcc-multilib
     qemu
 
-Running ``./setup.sh`` installs all of the above along with a full
+Running ``./scripts/setup.sh`` installs all of the above along with a full
 cross‑compilation environment and the IA‑16 toolchain.
 
 Building
@@ -95,7 +95,7 @@ The optimization scripts use advanced Clang/LLVM features including:
 ## Standard Building
 
 Before building you may install a comprehensive cross‑compilation
-environment by running ``./setup.sh`` as root.  The script configures
+environment by running ``./scripts/setup.sh`` as root.  The script configures
 package repositories for multiple architectures and installs toolchains
 and emulators such as ``qemu`` to enable execution of foreign binaries,
 including 16‑bit and 32‑bit x86 programs.  This is optional for a

--- a/docs/build_steps.md
+++ b/docs/build_steps.md
@@ -1,7 +1,7 @@
 # Build Instructions for bcpl-compiler
 
 This document summarizes the recommended steps for setting up a development environment and building
-`bcpl-compiler` from source.  The repository includes a `setup.sh` script that installs
+`bcpl-compiler` from source.  The repository includes a `scripts/setup.sh` script that installs
 all required packages (compilers, emulators, analysis tools such as `valgrind`,
 `trace-cmd`, `strace`, etc.).
 

--- a/docs/sphinx/tools-utilities.rst
+++ b/docs/sphinx/tools-utilities.rst
@@ -105,7 +105,7 @@ Development Scripts
    * Generates documentation
    * Creates distribution packages
 
-**setup.sh**
+**scripts/setup.sh**
    Development environment setup:
    
    * Configures build environment


### PR DESCRIPTION
## Summary
- document `scripts/setup.sh` in quick start and build requirements
- update docs to reference `scripts/setup.sh` consistently

## Testing
- `./build.sh`
- `cd build/Release && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68aa5af1cc348331b87a7e3052b60cdf